### PR TITLE
Publish good practices to GitHub pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # generated files
 *.pdf
 *.html
+!docs/*.html
 
 # temporary files
 .*.swp

--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -3,8 +3,6 @@ include::_style/render.adoc[]
 
 Before you suggest _automation_ guidelines, please consider the _contribution_ guidelines layed out in this document.
 
-toc::[]
-
 == Writing
 
 . The guidelines are written in https://asciidoctor.org[asciidoc as described by Asciidoctor].
@@ -99,3 +97,7 @@ Examples:: These are examples
 +
 Even more examples...
 ====
+
+== Publishing
+
+Use for now the following manual command: `asciidoctor -a toc=left -o docs/index.html README.adoc`.

--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -15,7 +15,7 @@ The result looks then as the following template shows (you may copy & paste):
 +
 [source,asciidoc]
 ------------------------------------------------------------------------
-.[big]#**Do this and do not do that is the guideline**#
+== Do this and do not do that is the guideline
 [%collapsible]
 ====
 Explanations:: These are explanations
@@ -71,7 +71,7 @@ This is how one guideline as shown above looks like once rendered:
 
 // This is a duplicate from the above code, but rendered e.g. by GitHub, it shows how it's supposed to look like.
 
-.[big]#**Do this and do not do that is the guideline**#
+=== Do this and do not do that is the guideline
 [%collapsible]
 ====
 Explanations:: These are explanations

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 = Good Practices for Ansible - GPA
+include::_style/render.adoc[]
 
 == Introduction
 

--- a/_style/render.adoc
+++ b/_style/render.adoc
@@ -1,5 +1,5 @@
 :doctype: book
-:toc: macro
+:toc: auto
 :toclevels: 4
 :sectnumlevels: 6
 :numbered:

--- a/collections/README.adoc
+++ b/collections/README.adoc
@@ -1,1 +1,3 @@
 = Collections good practices
+
+NOTE: Work in Progress...

--- a/docs/CONTRIBUTE.html
+++ b/docs/CONTRIBUTE.html
@@ -445,7 +445,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel1">
 <li><a href="#_writing">1. Writing</a></li>
 <li><a href="#_contributing">2. Contributing</a></li>
-<li><a href="#_example">3. Example</a></li>
+<li><a href="#_example">3. Example</a>
+<ul class="sectlevel2">
+<li><a href="#_do_this_and_do_not_do_that_is_the_guideline">3.1. Do this and do not do that is the guideline</a></li>
+</ul>
+</li>
 <li><a href="#_publishing">4. Publishing</a></li>
 </ul>
 </div>
@@ -483,7 +487,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="rouge highlight"><code data-lang="asciidoc">.[big]#**Do this and do not do that is the guideline**#
+<pre class="rouge highlight"><code data-lang="asciidoc">== Do this and do not do that is the guideline
 [%collapsible]
 ====
 Explanations:: These are explanations
@@ -590,8 +594,10 @@ For example, "Sentences are written", not "Sentences should be written" or "Sent
 <div class="paragraph">
 <p>This is how one guideline as shown above looks like once rendered:</p>
 </div>
+<div class="sect2">
+<h3 id="_do_this_and_do_not_do_that_is_the_guideline">3.1. Do this and do not do that is the guideline</h3>
 <details>
-<summary class="title"><span class="big"><strong>Do this and do not do that is the guideline</strong></span></summary>
+<summary class="title">Details</summary>
 <div class="content">
 <div class="dlist">
 <dl>
@@ -631,6 +637,7 @@ For example, "Sentences are written", not "Sentences should be written" or "Sent
 </details>
 </div>
 </div>
+</div>
 <div class="sect1">
 <h2 id="_publishing">4. Publishing</h2>
 <div class="sectionbody">
@@ -642,7 +649,7 @@ For example, "Sentences are written", not "Sentences should be written" or "Sent
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-04-18 07:26:29 +0200
+Last updated 2021-04-18 07:30:17 +0200
 </div>
 </div>
 <style>

--- a/docs/CONTRIBUTE.html
+++ b/docs/CONTRIBUTE.html
@@ -1,0 +1,864 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>Contribution guidelines</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Contribution guidelines</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_writing">1. Writing</a></li>
+<li><a href="#_contributing">2. Contributing</a></li>
+<li><a href="#_example">3. Example</a></li>
+<li><a href="#_publishing">4. Publishing</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p>Before you suggest <em>automation</em> guidelines, please consider the <em>contribution</em> guidelines layed out in this document.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_writing">1. Writing</h2>
+<div class="sectionbody">
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>The guidelines are written in <a href="https://asciidoctor.org">asciidoc as described by Asciidoctor</a>.</p>
+</li>
+<li>
+<p>each guideline is made of one sentence, as easy to remember as possible, followed by a collapsible description, made of:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>explanations</p>
+</li>
+<li>
+<p>rationale</p>
+</li>
+<li>
+<p>examples</p>
+<div class="paragraph">
+<p>The result looks then as the following template shows (you may copy &amp; paste):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="asciidoc">.[big]#**Do this and do not do that is the guideline**#
+[%collapsible]
+====
+Explanations:: These are explanations
+
+Rationale:: This is the rationale
+
+Examples:: These are examples
++
+.A mini playbook example
+[source,yaml]
+----
+- name: a mini example of playbook
+  hosts: all
+  gather_facts: false
+  become: false
+
+  tasks:
+
+  - name: say what we all think
+    debug:
+      msg: asciidoctor is {{ my_private_thoughts }}
+----
++
+Even more examples...
+====</code></pre>
+</div>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+see how it looks like in the <a href="#_example">Example</a> section below.
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Those guidelines are grouped into sections and optionally sub-sections, as far as required for maintainability.</p>
+</li>
+<li>
+<p>Those (sub-)sections can be written in their own source file, but then are included with <code>include::directory/file.adoc[leveloffset=1]</code> in the parent section&#8217;s file.
+This makes sure that all source files are interlinked and can be rendered all together by rendering the top <code>README.adoc</code>, either with <code>asciidoctor</code> or with <code>asciidoctor-pdf</code>.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+this contribution file is obviously not meant for inclusion in the overall document.
+</td>
+</tr>
+</table>
+</div>
+</li>
+<li>
+<p>Each source file has a single title (the line starting with one equal sign) and can be rendered individually (the <code>leveloffset</code> is set such that it fits in the overall headings structure when included).</p>
+</li>
+<li>
+<p>The source code is written as readable as possible in its raw form, without impacting maintainability.</p>
+</li>
+<li>
+<p>We follow the <a href="https://asciidoctor.org/docs/asciidoc-recommended-practices/">Asciidoc recommended practices</a>.</p>
+</li>
+<li>
+<p>Sentences are written in the present tense form, avoid "should", "must", etc.
+For example, "Sentences are written", not "Sentences should be written" or "Sentences must be written". This avoids filler words.</p>
+</li>
+<li>
+<p>The <a href="https://en.wikipedia.org/wiki/Singular_they">singular "they"</a> is used to avoid the unreadable "he/she/it" construct and still be neutral.</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contributing">2. Contributing</h2>
+<div class="sectionbody">
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>Just fork the repository, create a Pull Request (PR) and offer your changes.</p>
+</li>
+<li>
+<p>Feel free to review existing PR and give your opinion</p>
+</li>
+<li>
+<p>Also an issue against one of the recommendations is a valid approach</p>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_example">3. Example</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This is how one guideline as shown above looks like once rendered:</p>
+</div>
+<details>
+<summary class="title"><span class="big"><strong>Do this and do not do that is the guideline</strong></span></summary>
+<div class="content">
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Explanations</dt>
+<dd>
+<p>These are explanations</p>
+</dd>
+<dt class="hdlist1">Rationale</dt>
+<dd>
+<p>This is the rationale</p>
+</dd>
+<dt class="hdlist1">Examples</dt>
+<dd>
+<p>These are examples</p>
+<div class="listingblock">
+<div class="title">Listing 1. A mini playbook example</div>
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">a mini example of playbook</span>
+  <span class="na">hosts</span><span class="pi">:</span> <span class="s">all</span>
+  <span class="na">gather_facts</span><span class="pi">:</span> <span class="no">false</span>
+  <span class="na">become</span><span class="pi">:</span> <span class="no">false</span>
+
+  <span class="na">tasks</span><span class="pi">:</span>
+
+  <span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">say what we all think</span>
+    <span class="na">debug</span><span class="pi">:</span>
+      <span class="na">msg</span><span class="pi">:</span> <span class="s">asciidoctor is {{ my_private_thoughts }}</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Even more examples&#8230;&#8203;</p>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+</details>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_publishing">4. Publishing</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Use for now the following manual command: <code>asciidoctor -a toc=left -o docs/index.html README.adoc</code>.</p>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-04-18 07:26:29 +0200
+</div>
+</div>
+<style>
+pre.rouge table td { padding: 5px; }
+pre.rouge table pre { margin: 0; }
+pre.rouge .cm {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .cp {
+  color: #999999;
+  font-weight: bold;
+}
+pre.rouge .c1 {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+pre.rouge .c, pre.rouge .ch, pre.rouge .cd, pre.rouge .cpf {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+pre.rouge .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+pre.rouge .ge {
+  color: #000000;
+  font-style: italic;
+}
+pre.rouge .gr {
+  color: #aa0000;
+}
+pre.rouge .gh {
+  color: #999999;
+}
+pre.rouge .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+pre.rouge .go {
+  color: #888888;
+}
+pre.rouge .gp {
+  color: #555555;
+}
+pre.rouge .gs {
+  font-weight: bold;
+}
+pre.rouge .gu {
+  color: #aaaaaa;
+}
+pre.rouge .gt {
+  color: #aa0000;
+}
+pre.rouge .kc {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kd {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kn {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kp {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kr {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kt {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .k, pre.rouge .kv {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .mf {
+  color: #009999;
+}
+pre.rouge .mh {
+  color: #009999;
+}
+pre.rouge .il {
+  color: #009999;
+}
+pre.rouge .mi {
+  color: #009999;
+}
+pre.rouge .mo {
+  color: #009999;
+}
+pre.rouge .m, pre.rouge .mb, pre.rouge .mx {
+  color: #009999;
+}
+pre.rouge .sa {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .sb {
+  color: #d14;
+}
+pre.rouge .sc {
+  color: #d14;
+}
+pre.rouge .sd {
+  color: #d14;
+}
+pre.rouge .s2 {
+  color: #d14;
+}
+pre.rouge .se {
+  color: #d14;
+}
+pre.rouge .sh {
+  color: #d14;
+}
+pre.rouge .si {
+  color: #d14;
+}
+pre.rouge .sx {
+  color: #d14;
+}
+pre.rouge .sr {
+  color: #009926;
+}
+pre.rouge .s1 {
+  color: #d14;
+}
+pre.rouge .ss {
+  color: #990073;
+}
+pre.rouge .s, pre.rouge .dl {
+  color: #d14;
+}
+pre.rouge .na {
+  color: #008080;
+}
+pre.rouge .bp {
+  color: #999999;
+}
+pre.rouge .nb {
+  color: #0086B3;
+}
+pre.rouge .nc {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .no {
+  color: #008080;
+}
+pre.rouge .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+pre.rouge .ni {
+  color: #800080;
+}
+pre.rouge .ne {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nf, pre.rouge .fm {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nl {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nn {
+  color: #555555;
+}
+pre.rouge .nt {
+  color: #000080;
+}
+pre.rouge .vc {
+  color: #008080;
+}
+pre.rouge .vg {
+  color: #008080;
+}
+pre.rouge .vi {
+  color: #008080;
+}
+pre.rouge .nv, pre.rouge .vm {
+  color: #008080;
+}
+pre.rouge .ow {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .o {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .w {
+  color: #bbbbbb;
+}
+pre.rouge {
+  background-color: #f8f8f8;
+}
+</style>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,2021 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.10">
+<title>Good Practices for Ansible - GPA</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment @import statement to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+:not(pre)>code.nobreak{word-wrap:normal}
+:not(pre)>code.nowrap{white-space:nowrap}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
+pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
+pre.pygments .lineno::before{content:"";margin-right:-.125em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Good Practices for Ansible - GPA</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_introduction">1. Introduction</a></li>
+<li><a href="#_automation_structures">2. Automation structures</a></li>
+<li><a href="#_roles_good_practices_for_ansible">3. Roles Good Practices for Ansible</a>
+<ul class="sectlevel2">
+<li><a href="#_background">3.1. Background</a></li>
+<li><a href="#_basics">3.2. Basics</a></li>
+<li><a href="#_interface_design_considerations">3.3. Interface design considerations</a>
+<ul class="sectlevel3">
+<li><a href="#_basic_design">3.3.1. Basic design</a></li>
+<li><a href="#_naming_things">3.3.2. Naming things</a></li>
+<li><a href="#_providers">3.3.3. Providers</a></li>
+</ul>
+</li>
+<li><a href="#_implementation_considerations">3.4. Implementation considerations</a>
+<ul class="sectlevel3">
+<li><a href="#_role_structure">3.4.1. Role Structure</a></li>
+<li><a href="#_check_mode_and_idempotency_issues">3.4.2. Check Mode and Idempotency Issues</a></li>
+<li><a href="#_supporting_multiple_distributions_and_versions">3.4.3. Supporting multiple distributions and versions</a>
+<ul class="sectlevel4">
+<li><a href="#_platform_specific_variables">3.4.3.1. Platform specific variables</a></li>
+<li><a href="#_platform_specific_tasks">3.4.3.2. Platform specific tasks</a></li>
+</ul>
+</li>
+<li><a href="#_supporting_multiple_providers">3.4.4. Supporting multiple providers</a></li>
+<li><a href="#_generating_files_from_templates">3.4.5. Generating files from templates</a></li>
+<li><a href="#_yaml_and_jinja2_syntax">3.4.6. YAML and Jinja2 Syntax</a></li>
+<li><a href="#_python_guidelines">3.4.7. Python Guidelines</a></li>
+<li><a href="#_ansible_best_practices">3.4.8. Ansible Best Practices</a>
+<ul class="sectlevel4">
+<li><a href="#_vars_vs_defaults">3.4.8.1. Vars vs Defaults</a></li>
+</ul>
+</li>
+<li><a href="#_documentation_conventions">3.4.9. Documentation conventions</a></li>
+</ul>
+</li>
+<li><a href="#_references">3.5. References</a></li>
+</ul>
+</li>
+<li><a href="#_collections_good_practices">4. Collections good practices</a></li>
+<li><a href="#_playbooks_good_practices">5. Playbooks good practices</a></li>
+<li><a href="#_inventories_good_practices_for_ansible">6. Inventories Good Practices for Ansible</a></li>
+<li><a href="#_plugins_good_practices">7. Plugins good practices</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_introduction">1. Introduction</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><a href="https://ansible.com/">Ansible</a> is simple, flexible, and powerful. Like any powerful tool, there are many ways to use it, some better than others.</p>
+</div>
+<div class="paragraph">
+<p>This document aims to gather good practices from the field of Ansible practitioners at Red Hat, consultants, developers, and others.
+And thus it strives to give any Red Hat employee, partner or customer (or any Ansible user) a guideline from which to start in good conditions their automation journey.</p>
+</div>
+<div class="paragraph">
+<p>Those are opiniated guidelines based on the experience of many people.
+They are not meant to be followed blindly if they don&#8217;t fit the reader&#8217;s specific use case, organization or needs;
+there is a reason why they are called <em>good</em> and not <em>best</em> practices.</p>
+</div>
+<div class="paragraph">
+<p>The reader of this document is expected to have working practice of Ansible.
+If they are new to Ansible, the <a href="https://docs.ansible.com/">official Ansible documentation</a> is a better place to start.</p>
+</div>
+<div class="paragraph">
+<p>This document is split in six main sections.
+Each section covers a different aspect of automation using Ansible (and in a broader term the whole <a href="https://www.redhat.com/en/technologies/management/ansible">Red Hat Ansible Automation Platform</a>, including Ansible Tower):</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
+<li>
+<p>structures: we need to know what to use for which purpose before we can delve into the details, this section explains this.</p>
+</li>
+<li>
+<p>roles: as we recommend to use roles to host the most actual Ansible code, this is also where we&#8217;ll cover the more low level aspects of code (tasks, variables, etc&#8230;&#8203;).</p>
+</li>
+<li>
+<p>collections</p>
+</li>
+<li>
+<p>playbooks</p>
+</li>
+<li>
+<p>inventories</p>
+</li>
+<li>
+<p>plugins</p>
+</li>
+</ol>
+</div>
+<div class="paragraph">
+<p>Each section is then made of guidelines, one sentence hopefully easy to remember, followed by description, rationale and examples.
+The HTML version of this document makes the content collapsable so that all guidelines can be seen at once in a very overseeable way, for the reader to uncollapse the content of guidelines they is interested in.</p>
+</div>
+<div class="paragraph">
+<p>A rationale is expected for each good practice, with a reference if applicable.
+It is really helpful to know not only how to do certain things, but why to do them in this way.
+It will also help with further revisions of the standards as some items may become obsolete or no longer applicable.
+If the reason is not included, there is a risk of keeping items that are no longer applicable, or alternatively blindly removing items that should be kept.
+It also has great educational value for understanding how things actually work (or how they don&#8217;t).</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_automation_structures">2. Automation structures</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Before we start to describe roles, playbooks, etc, we need to decide which one we use for what.
+This section is meant for topics which span across multiple structures and don&#8217;t fit nicely within one.</p>
+</div>
+<details>
+<summary class="title"><span class="big"><strong>Define which structure to use for which purpose</strong></span></summary>
+<div class="content">
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Explanations</dt>
+<dd>
+<p>define for which use case to use roles, playbooks, potentially workflows (in Ansible Tower/AWX), and how to split the code you write.</p>
+</dd>
+<dt class="hdlist1">Rationale</dt>
+<dd>
+<p>especially when writing automation in a team, it is important to have a certain level of consistence and make sure everybody has the same understanding.
+By lack of doing so, your automation becomes unreadable and difficult to grasp for new members or even for existing members.</p>
+<div class="paragraph">
+<p>This structure will also help you to have a consistent level of modelization so that re-usability becomes easier.
+If one team member uses roles where another one uses playbooks, they will both struggle to reuse the code of each other.
+Metaphorically speaking, only if stones have been cut at roughly the same size, can they be properly used to build a house.</p>
+</div>
+</dd>
+<dt class="hdlist1">Examples</dt>
+<dd>
+<p>The following is only one example of how to structure your content but has proven robust enough on multiple occasions.</p>
+<div class="imageblock">
+<div class="content">
+<img src="ansible_structures.svg" alt="a hierarchy of landscape type function and component">
+</div>
+<div class="title">Figure 1. Structure of Automation</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>a <em>landscape</em> is anything you want to deploy at once, the underlay of your cloud, a three tiers application, a complete application cluster&#8230;&#8203;
+This level is represented at best by a Tower/AWX workflow, potentially by a "playbook of playbooks", i.e. a playbook made of imported <em>type</em> playbooks, as introduced next.</p>
+</li>
+<li>
+<p>a <em>type</em> must be defined such that each managed host has one and only one type, applicable using a unique playbook.</p>
+</li>
+<li>
+<p>each type is then made of multiple <em>functions</em>, represented by roles, so that the same function used by the same <em>type</em> can be re-used, written only once.</p>
+</li>
+<li>
+<p>and finally <em>components</em> are used to split a <em>function</em> in maintainable bits. By default a component is a task file within the <em>function</em>-role, if the role becomes too big, there is a case for splitting the <em>function</em> role into multiple <em>component</em> roles.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+if <em>functions</em> are defined mostly for re-usability purposes, <em>components</em> are more used for maintainability / readability purposes. A re-usable component might be a candidate for promotion to a function.
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Let&#8217;s have a more concrete example to clarify:</p>
+</div>
+</li>
+<li>
+<p>as already written, a <em>landscape</em> could be a three tier application with web-front-end, middleware and database.
+We would probably create a workflow to deploy this landscape at once.</p>
+</li>
+<li>
+<p>our types would be relatively obvious here as we would have "web-front-end server", "middleware server" and "database server".
+Each type can be fully deployed by one and only one playbook (avoid having numbered playbooks and instructions on how to call them one after the other).</p>
+</li>
+<li>
+<p>each server type is then made up of one or more <em>functions</em>, each implemented as a role.
+For example, the middleware server type could be made of a "virtual machine" (to create the virtual machine hosting the middleware server), a "base Linux OS" and a "JBoss application server" function.</p>
+</li>
+<li>
+<p>and then the base OS role could be made of multiple components (DNS, NTP, SSH, etc), each represented by a separate <code>tasks/{component}.yml</code> file, included or imported from the <code>tasks/main.yml</code> file of the <em>function</em>-role.
+If a component becomes too big to fit within one task file, it might make sense that it gets its own component-role, included from the function-role.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+in terms of re-usability, see how you could simply create a new "integrated three tiers server" type (e.g. for test purposes), by just re-combining the "virtual machine", "base Linux OS", "JBoss application server", "PostgreSQL database" and "Apache web-server" function-roles into one new playbook.
+</td>
+</tr>
+</table>
+</div>
+</li>
+</ul>
+</div>
+</dd>
+</dl>
+</div>
+<div class="paragraph">
+<p>Beware that those rules, once defined, shouldn&#8217;t be applied too strictly.
+There can always be reasons for breaking the rules, and sometimes the discussion you can have in the team to decide what is what is more important.
+For example if a "hardened Linux OS" and a "normal Linux OS" are two different functions, or the same function with different parameters. You could consider SSH to be a function on its own and not a component of the base OS.
+Also, external re-usable roles and collections, obviously not respecting your rules, might force you to bend them.
+Important is to break the rules not by ignorance of those but because of good and practical reasons.
+Respecting the rules is to know and acknowledge them, not to follow them blindly even if they don&#8217;t make sense.
+As long as exceptions are discussed openly in the team, they won&#8217;t hurt.</p>
+</div>
+</div>
+</details>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_roles_good_practices_for_ansible">3. Roles Good Practices for Ansible</h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+this section has been imported "as-is" from the <a href="https://github.com/oasis-roles/meta_standards">OASIS metastandards repository</a> and still requires re-formatting to fit the overall structure.
+</td>
+</tr>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_background">3.1. Background</h3>
+<div class="paragraph">
+<p>The goal of the Ansible Metateam project (specifically, the <a href="https://github.com/linux-system-roles">Linux System Roles
+project</a>) is to provide a stable and consistent user
+interface to multiple operating systems (multiple versions of RHEL in the downstream RHEL System
+Roles package, additionally CentOS, Fedora at least). Stable and consistent means that the same
+Ansible playbook will be usable to manage the equivalent functionality in the supported versions
+without the administrator (the user of the role) being forced to change anything in the playbook
+(the roles should serve as abstractions to shield the administrator from differences). Of course,
+this means that the interface of the roles should be itself stable (i.e. changing only in a backward
+compatible way). This implies a great responsibility in the design of the interface, because the
+interface, unlike the underlying implementation, can not be easily changed.</p>
+</div>
+<div class="paragraph">
+<p>The differences in the underlying operating systems that the roles need to compensate for are
+basically of two types:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Trivial differences like changed names of packages, services, changed location of configuration
+files. Roles must deals with those by using internal variables based on the OS defaults. This is
+fairly simple, but still it brings value to the user, because they then do not have to worry about
+keeping up with such trivial changes.</p>
+</li>
+<li>
+<p>Change of the underlying implementation of a given functionality. Quite often, there are multiple
+packages/components implementing the same functionality. Classic examples are the various MTAs
+(sendmail, postfix, qmail, exim), FTP daemons, etc. In the context of Linux System Roles, we call
+them &#8220;providers&#8221;. The goal of the roles is to abstract even such differences, so that when the OS
+changes to a different component (provider), the role continues to work. An example is time
+synchronization, where RHEL used to use the ntpd package, then chrony was introduced and became
+the default, but both components have been shipped in RHEL 6 and RHEL 7, until finally ntpd was
+dropped from RHEL 8, leaving only chrony. A role covering time synchronization should therefore
+support both components with the same interface, and on systems which ship both components, both
+should be supported. The appropriate supported component should be automatically selected on
+systems that ship only one of them. This covers several related use cases:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Users that want to manage multiple major releases of the system simultaneously with a single playbook.</p>
+</li>
+<li>
+<p>Users that want to migrate to a new version of the system without changing their automation (playbook).</p>
+</li>
+<li>
+<p>Users who want to switch to a different provider in the same version of the OS (like switching
+from ntpd to chrony to RHEL 7) and keep the same playbook.</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Designing the interface in the latter case is difficult because it has to be sufficiently abstract
+to cover different providers. We, for example, do not provide an email role in the Linux System
+Roles project, only a postfix role, because the underlying implementations (sendmail, postfix) were
+deemed to be too divergent. Generally, an abstract interface should be something that should be
+always aimed for though, especially if there are multiple providers in use already, and in
+particular when the default provider is changing or is known to be likely to change in the next
+major releases.</p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_basics">3.2. Basics</h3>
+<div class="ulist">
+<ul>
+<li>
+<p>Every repository in the AGP-roles namespace should be a valid Ansible Galaxy compatible role
+with the exception of any whose names begin with "meta_", such as this one.</p>
+</li>
+<li>
+<p>New roles should be initiated in line with the skeleton directory, which has standard boilerplate
+code for a Galaxy-compatible Ansible role and some enforcement around these standards</p>
+</li>
+<li>
+<p>Use <a href="https://semver.org/">semantic versioning</a> for Git release tags.  Use
+0.y.z before the role is declared stable (interface-wise).  Although it has
+not been a problem so far for linux system roles, since they use strict X.Y.Z
+versioning, you should be aware that there are some
+<a href="https://github.com/ansible/ansible/issues/67512">restrictions</a> for Ansible
+Galaxy and Automation Hub.  The versioning must be in strict X.Y.Z[ab][W]
+format, where X, Y, and Z are integers.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_interface_design_considerations">3.3. Interface design considerations</h3>
+<div class="paragraph">
+<p>What should a role do and how can a user tell it what to do.</p>
+</div>
+<div class="sect3">
+<h4 id="_basic_design">3.3.1. Basic design</h4>
+<div class="paragraph">
+<p>Try to design the interface focused on the functionality, not on the software implementation behind
+it. This will help abstracting differences between different providers (see above), and help the
+user to focus on the functionality, not on technical details.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_naming_things">3.3.2. Naming things</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>All YAML or Python files, variables, arguments, repositories, and other such names (like
+dictionary keys) should be valid Python identifiers following standard naming conventions of being
+in snake_case_naming_schemes. In particular, do not use special characters other than
+underscore in variable names, even if YAML/JSON allow them. (Using such variables in Jinja2 or
+Python would be then very confusing and probably not functional.) Rationale: even when Ansible
+currently allows names that are not valid identifier, it may stop allowing them in the future, as
+it happened in the past already. Making all names valid identifiers will avoid encountering
+problems in the future. Dictionary keys that are not valid identifier are also less intuitive to
+use in Jinja2 (a dot in a dictionary key would be particularly confusing).</p>
+</li>
+<li>
+<p>Names should be mnemonic and descriptive and not strive to shorten more than necessary. Systems
+support long identifier names, so use them to be descriptive</p>
+</li>
+<li>
+<p>All defaults and all arguments to a role should have a name that begins with the role name to help
+avoid collision with other names. Avoid names like <code>packages</code> in favor of a name like <code>foo_packages</code>.
+(Rationale: Ansible has no namespaces, doing so reduces the potential for conflicts and makes
+clear what role a given variable belongs to.)</p>
+</li>
+<li>
+<p>Same argument applies for modules provided in the roles, they also need a <code>$ROLENAME_</code> prefix:
+<code>foo_module</code>. While they are usually implementation details and not intended for direct use in
+playbooks, the unfortunate fact is that importing a role makes them available to the rest of the
+playbook and therefore creates opportunities for name collisions.</p>
+</li>
+<li>
+<p>Moreover, internal variables (those that are not expected to be set by users) are to be prefixed
+by two underscores: <code>__foo_variable</code>. (Rationale: role variables, registered variables, custom
+facts are usually intended to be local to the role, but in reality are not local to the role - as
+such a concept does not exist, and pollute the global namespace. Using the name of the role
+reduces the potential for name conflicts and using the underscores clearly marks the variables as
+internals and not part of the common interface. The two underscores convention has prior art in
+some popular roles like
+<a href="https://github.com/geerlingguy/ansible-role-apache/blob/f2b91ac84001db3fd4b43306a8f73f1a54f96f7d/vars/Debian.yml#L8">geerlingguy.ansible-role-apache</a>). This
+includes variables set by set_fact and register, because they persist in the namespace after the
+role has finished!</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_providers">3.3.3. Providers</h4>
+<div class="paragraph">
+<p>When there are multiple implementations of the same functionality, we call them &#8220;providers&#8221;. A role
+supporting multiple providers should have an input variable called <code>$ROLENAME_provider</code>. If this
+variable is not defined, the role should detect the currently running provider on the system, and
+respect it. (Rationale: users can be surprised if the role changes the provider if they are running
+one already.) If there is no provider currently running, the role should select one according to the
+OS version. (E.g. on RHEL 7, chrony should be selected as the provider of time synchronization,
+unless there is ntpd already running on the system, or user requests it specifically. Chrony should
+be chosen on RHEL 8 as well, because it is the only provider available.) The role should set a
+variable or custom fact called <code>$ROLENAME_provider_os_default</code> to the appropriate default value for
+the given OS version. (Rationale: users may want to set all their managed systems to a consistent
+state, regardless of the provider that has been used previously. Setting <code>$ROLENAME_provider</code> would
+achieve it, but is suboptimal, because it requires selecting the appropriate value by the user, and
+if the user has multiple system versions managed by a single playbook, a common value supported by
+all of them may not even exist. Moreover, after a major upgrade of their systems, it may force the
+users to change their playbooks to change their <code>$ROLENAME_provider</code> setting, if the previous value
+is not supported anymore. Exporting <code>$ROLENAME_provider_os_default</code> allows the users to set
+<code>$ROLENAME_provider: "{{ $ROLENAME_provider_os_default }}"</code> (thanks to the lazy variable evaluation
+in Ansible) and thus get a consistent setting for all the systems of the given OS version without
+having to decide what the actual value is - the decision is delegated to the role.)</p>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_implementation_considerations">3.4. Implementation considerations</h3>
+<div class="sect3">
+<h4 id="_role_structure">3.4.1. Role Structure</h4>
+<div class="paragraph">
+<p>Avoid testing for distribution and version in tasks. Rather add a variable file to "vars/"
+for each supported distribution and version with the variables that need to change according
+to the distribution and version. This way it is easy to add support to a new distribution by
+simply dropping a new file in to "vars/", see below
+<a href="#supporting-multiple-distributions-and-versions">Supporting multiple distributions and versions</a>. See also
+<a href="#vars-vs-defaults">Vars vs Defaults</a> which mandates "Avoid embedding large lists or 'magic values' directly
+into the playbook." Since distribution-specific values are kind of "magic values", it applies to them. The
+same logic applies for providers: a role can load a provider-specific variable file, include a
+provider-specific task file, or both, as needed. Consider making paths to templates internal variables if you
+need different templates for different distributions.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_check_mode_and_idempotency_issues">3.4.2. Check Mode and Idempotency Issues</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>The role should work in check mode, meaning that first of all, they should not fail check mode, and
+they should also not report changes when there are no changes to be done. If it is not possible
+to support it, please state the fact and provide justification in the documentation.
+This applies to the first run of the role.</p>
+</li>
+<li>
+<p>Reporting changes properly is related to the other requirement: <strong>idempotency</strong>. Roles
+should not perform changes when applied a second time to the same system with the same parameters,
+and it should not report that changes have been done if they have not been done. Due to this,
+using <code>command:</code> is problematic, as it always reports changes. Therefore, override the result by
+using <code>changed_when:</code></p>
+</li>
+<li>
+<p>Concerning check mode, one usual obstacle to supporting it are registered variables. If there
+is a task which registers a variable and this task does not get executed (e.g. because it is a
+<code>command:</code> or another task which is not properly idempotent), the variable will not get registered
+and further accesses to it will fail (or worse, use the previous value, if the role has been
+applied before in the play, because variables are global and there is no way to unregister them).
+To fix, either use a properly idempotent module to obtain the information (e.g. instead of
+using <code>command: cat</code> to read file into a registered variable, use <code>slurp</code> and apply <code>.content|b64decode</code>
+to the result like
+<a href="https://github.com/linux-system-roles/kdump/pull/23/files#diff-d2414d4ec8ba189e1a244b0afc9aa81eL8">here</a>),
+or apply proper <code>check_mode:</code> and <code>changed_when:</code> attributes to the task.
+<a href="https://github.com/ansible/molecule/issues/128#issue-135906202">more_info</a>.</p>
+</li>
+<li>
+<p>Another problem are commands that you need to execute to make changes. In check mode, you
+need to test for changes without actually applying them. If the command has some kind of "--dry-run"
+flag to enable executing without making actual changes, use it in check_mode (use the variable
+<code>ansible_check_mode</code> to determine whether we are in check mode). But you then need to set <code>changed_when:</code>
+according to the command status or output to indicate changes. See
+(<a href="https://github.com/linux-system-roles/selinux/pull/38/files#diff-2444ad0870f91f17ca6c2a5e96b26823L101" class="bare">https://github.com/linux-system-roles/selinux/pull/38/files#diff-2444ad0870f91f17ca6c2a5e96b26823L101</a>) for
+an example.</p>
+</li>
+<li>
+<p>Another problem is using commands that get installed during the install phase, which is
+skipped in check mode. This will make check mode fail if the role has not been executed
+before (and the packages are not there), but does the right thing if check mode is executed after
+normal mode.</p>
+</li>
+<li>
+<p>To view reasoning for supporting why check mode in first execution may not be worthwhile: see
+<a href="https://github.com/ansible/molecule/issues/128#issuecomment-245009843">here</a>. If this is to be supported,
+see hhaniel&#8217;s proposal
+<a href="https://github.com/linux-system-roles/timesync/issues/27#issuecomment-472466223">here</a>, which seems to
+properly guard even against such cases.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_supporting_multiple_distributions_and_versions">3.4.3. Supporting multiple distributions and versions</h4>
+<div class="sect4">
+<h5 id="_platform_specific_variables">3.4.3.1. Platform specific variables</h5>
+<div class="paragraph">
+<p>You normally use <code>vars/main.yml</code> (automatically included) to set variables
+used by your role.  If some variables need to be parameterized according to
+distribution and version (name of packages, configuration file paths, names of
+services), use this in the beginning of your <code>tasks/main.yml</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">Set platform/version specific variables</span>
+  <span class="na">include_vars</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">__rolename_vars_file</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">loop</span><span class="pi">:</span>
+    <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['os_family']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+    <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+    <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_major_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+    <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+  <span class="na">vars</span><span class="pi">:</span>
+    <span class="na">__rolename_vars_file</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">role_path</span><span class="nv"> </span><span class="s">}}/vars/{{</span><span class="nv"> </span><span class="s">item</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">when</span><span class="pi">:</span> <span class="s">__rolename_vars_file is file</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The files in the <code>loop</code> are in order from least specific to most specific:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>os_family</code> covers a group of closely related platforms (e.g. <code>RedHat</code>
+covers RHEL, CentOS, Fedora)</p>
+</li>
+<li>
+<p><code>distribution</code> (e.g. <code>Fedora</code>) is more specific than <code>os_family</code></p>
+</li>
+<li>
+<p><code>distribution</code>_<code>distribution_major_version</code> (e.g. <code>RedHat_8</code>) is more
+specific than <code>distribution</code></p>
+</li>
+<li>
+<p><code>distribution</code>_<code>distribution_version</code> (e.g. <code>RedHat_8.3</code>) is the most
+specific</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>See <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#ansible-facts-distribution">Commonly Used
+Facts</a>
+for an explanation of the facts and their common values.</p>
+</div>
+<div class="paragraph">
+<p>Each file in the <code>loop</code> list will allow you to add or override variables to
+specialize the values for platform and/or version.  Using the <code>when: item is
+file</code> test means that you do not have to provide all of the <code>vars/</code> files,
+only the ones you need.  For example, if every platform except Fedora uses
+<code>srv_name</code> for the service name, you can define <code>myrole_service: srv_name</code> in
+<code>vars/main.yml</code> then define <code>myrole_service: srv2_name</code> in <code>vars/Fedora.yml</code>.
+In cases where this would lead to duplicate vars files for similar
+distributions (e.g. CentOS 7 and RHEL 7), use symlinks to avoid the
+duplication.</p>
+</div>
+<div class="paragraph">
+<p><strong>NOTE</strong>: With this setup, files can be loaded twice.  For example, on Fedora,
+the <code>distribution_major_version</code> is the same as <code>distribution_version</code> so the
+file <code>vars/Fedora_31.yml</code> will be loaded twice if you are managing a Fedora 31
+host.  If <code>distribution</code> is <code>RedHat</code> then <code>os_family</code> will also be <code>RedHat</code>,
+and <code>vars/RedHat.yml</code> will be loaded twice. This is usually not a problem -
+you will be replacing the variable with the same value, and the performance
+hit is negligible.  If this is a problem, construct the file list as a list
+variable, and filter the variable passed to <code>loop</code> using the <code>unique</code> filter
+(which preserves the order):</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">Set vars file list</span>
+  <span class="na">set_fact</span><span class="pi">:</span>
+    <span class="na">__rolename_vars_file_list</span><span class="pi">:</span>
+      <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['os_family']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+      <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+      <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_major_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+      <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+
+<span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">Set platform/version specific variables</span>
+  <span class="na">include_vars</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">__rolename_vars_file</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">loop</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">__rolename_vars_file_list</span><span class="nv"> </span><span class="s">|</span><span class="nv"> </span><span class="s">unique</span><span class="nv"> </span><span class="s">|</span><span class="nv"> </span><span class="s">list</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">vars</span><span class="pi">:</span>
+    <span class="na">__rolename_vars_file</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">role_path</span><span class="nv"> </span><span class="s">}}/vars/{{</span><span class="nv"> </span><span class="s">item</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">when</span><span class="pi">:</span> <span class="s">__rolename_vars_file is file</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Or define your <code>__rolename_vars_file_list</code> in your <code>vars/main.yml</code>.</p>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_platform_specific_tasks">3.4.3.2. Platform specific tasks</h5>
+<div class="paragraph">
+<p>Platform specific tasks, however, are different.  You probably want to perform
+platform specific tasks once, for the most specific match.  In that case, use
+<code>lookup('first_found')</code> with the file list in order of most specific to least
+specific, including a "default":</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">Perform platform/version specific tasks</span>
+  <span class="na">include_tasks</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">lookup('first_found',</span><span class="nv"> </span><span class="s">__rolename_ff_params)</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">vars</span><span class="pi">:</span>
+    <span class="na">__rolename_ff_params</span><span class="pi">:</span>
+      <span class="na">files</span><span class="pi">:</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_major_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['os_family']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">default.yml"</span>
+      <span class="na">paths</span><span class="pi">:</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">role_path</span><span class="nv"> </span><span class="s">}}/tasks/setup"</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Then you would provide <code>tasks/setup/default.yml</code> to do the generic setup, and
+e.g. <code>tasks/setup/Fedora.yml</code> to do the Fedora specific setup.  The
+<code>tasks/setup/default.yml</code> is required in order to use <code>lookup('first_found')</code>,
+which will give an error if no file is found.</p>
+</div>
+<div class="paragraph">
+<p>If you want to have the "use first file found" semantics, but do not want to
+have to provide a default file, add <code>skip: true</code>:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">Perform platform/version specific tasks</span>
+  <span class="na">include_tasks</span><span class="pi">:</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">lookup('first_found',</span><span class="nv"> </span><span class="s">__rolename_ff_params)</span><span class="nv"> </span><span class="s">}}"</span>
+  <span class="na">vars</span><span class="pi">:</span>
+    <span class="na">__rolename_ff_params</span><span class="pi">:</span>
+      <span class="na">files</span><span class="pi">:</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution']</span><span class="nv"> </span><span class="s">}}_{{</span><span class="nv"> </span><span class="s">ansible_facts['distribution_version']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">ansible_facts['os_family']</span><span class="nv"> </span><span class="s">}}.yml"</span>
+      <span class="na">paths</span><span class="pi">:</span>
+        <span class="pi">-</span> <span class="s2">"</span><span class="s">{{</span><span class="nv"> </span><span class="s">role_path</span><span class="nv"> </span><span class="s">}}/tasks/setup"</span>
+      <span class="na">skip</span><span class="pi">:</span> <span class="no">true</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>NOTE</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Use <code>include_tasks</code> or <code>include_vars</code> with <code>lookup('first_found')</code> instead
+of <code>with_first_found</code>.  <code>loop</code> is not needed - the include forms take a
+string or a list directly.</p>
+</li>
+<li>
+<p>Always specify the explicit, absolute path to the files to be included,
+using <code>{{ role_path }}/vars</code> or <code>{{ role_path }}/tasks</code>, when using these
+idioms. See below "Ansible Best Practices" for more information.</p>
+</li>
+<li>
+<p>Use the <code>ansible_facts['name']</code> bracket notation rather than the
+<code>ansible_facts.name</code> or <code>ansible_name</code> form.  For example, use
+<code>ansible_facts['distribution']</code> instead of <code>ansible_distribution</code> or
+<code>ansible.distribution</code>.  The <code>ansible_name</code> form relies on fact injection,
+which can break if there is already a fact of that name. Also, the bracket
+notation is what is used in Ansible documentation such as <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#ansible-facts-distribution">Commonly Used
+Facts</a>
+and <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html#operating-system-and-distribution-variance">Operating System and Distribution
+Variance</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_supporting_multiple_providers">3.4.4. Supporting multiple providers</h4>
+<div class="paragraph">
+<p>Use a task file per provider and include it from the main task file, like this example from <code>storage:</code></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="rouge highlight"><code data-lang="yaml"><span class="pi">-</span> <span class="na">name</span><span class="pi">:</span> <span class="s">include the appropriate provider tasks</span>
+  <span class="na">include_tasks</span><span class="pi">:</span> <span class="s2">"</span><span class="s">main_{{</span><span class="nv"> </span><span class="s">storage_provider</span><span class="nv"> </span><span class="s">}}.yml"</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>The same process should be used for variables (not defaults, as defaults can
+not be loaded according to a variable).  You should guarantee that a file
+exists for each provider supported, or use an explicit, absolute path using
+<code>role_path</code>.  See below "Ansible Best Practices" for more information.</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_generating_files_from_templates">3.4.5. Generating files from templates</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Comment with <code>{{ ansible_managed }}</code>at the top of the file.
+<a href="https://docs.ansible.com/ansible/latest/modules/template_module.html#template-module">more_info</a></p>
+</li>
+<li>
+<p>When commenting, don&#8217;t include anything like "Last modified: {{ date }}". This would change the file at
+every application of the role, even if it doesn&#8217;t need to be changed for other reasons, and thus break
+proper change reporting.</p>
+</li>
+<li>
+<p>Use standard module parameters for backups, keep it on unconditionally (<code>backup: true</code>). (Until there is a
+user request to have it configurable.)</p>
+</li>
+<li>
+<p>Make prominently clear in the HOWTO (at the top) what settings/configuration files are replaced by the role
+instead of just modified.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_yaml_and_jinja2_syntax">3.4.6. YAML and Jinja2 Syntax</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Indent at two spaces</p>
+</li>
+<li>
+<p>List contents should be indented beyond the list definition</p>
+</li>
+<li>
+<p>It is easy to split long Jinja2 expressions into <a href="https://github.com/linux-system-roles/timesync/pull/47/files">multiple
+lines</a>.  If the
+<code>when:</code> condition results in a line that is too long, and is an <code>and</code>
+expression, then break it into a list of conditions.  Ansible will <code>and</code> them
+together (see: <a href="https://github.com/linux-system-roles/timesync/pull/36">[1]</a>
+<a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#the-when-statement">[2]</a>).
+Multiple conditions that all need to be true (a logical <code>and</code>) can also be
+specified as a list, but beware of bare variables in <code>when:</code>.</p>
+</li>
+<li>
+<p>All roles need to, minimally, pass a basic ansible-playbook syntax check run</p>
+</li>
+<li>
+<p>All task arguments should be spelled out in YAML style and not use <code>key=value</code> type of arguments</p>
+</li>
+<li>
+<p>All YAML files need to pass standard yamllint syntax with the modifications listed in
+<a href="https://github.com/AGP-roles/meta_test/blob/master/yamllint.yml">yamllint.yml</a> in the
+<a href="https://github.com/AGP-roles/meta_test">meta_test</a> role. These modifications are minimal:
+document starter characters (the initial
+<code>---</code> string at the top of a file) should not be used, and it is not necessary to start every comment
+with a space. Most comments should start with a space, but no space is allowed when a comment is
+documenting an optional variable with its default value.</p>
+<div class="ulist">
+<ul>
+<li>
+<p>As a result of being able to pass basic YAML lint, avoid the use of <code>True</code> and <code>False</code> for boolean values
+in playbooks. These values are sometimes used because they are the words Python uses. However, they are
+improper YAML and will be treated as either strings or as booleans but generating a warning depending on
+the particular YAML implementation.</p>
+</li>
+<li>
+<p>Do not use the Ansible-specific <code>yes</code> and <code>no</code> as boolean values in YAML as these are completely
+custom extensions used by Ansible and are not part of the YAML spec.</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Although it is not expressly forbidden, comments in playbooks should be avoided when possible. The task
+<code>name</code> value should be descriptive enough to tell what a task does. Variables should be well commented in
+the <code>defaults</code> and <code>vars</code> directories and should, therefore, not need explanation in the playbooks
+themselves.</p>
+</li>
+<li>
+<p>All Jinja2 template points should have a single space separating the template markers from the variable
+name inside. For instance, always write it as <code>{{ variable_name_here }}</code>. The same goes if the value is
+an expression. <code>{{ variable_name | default('hiya, doc') }}</code></p>
+</li>
+<li>
+<p>When naming files, use the <code>.yml</code> extension and <em>not</em> <code>.yaml</code>.  <code>.yml</code> is what
+<code>ansible-galaxy init</code> does when creating a new role template.</p>
+</li>
+<li>
+<p>Double quotes should be used for YAML strings with the exception of Jinja2
+strings which will use single quotes.</p>
+</li>
+<li>
+<p>Do not use quotes unless you have to, especially for short strings like
+<code>present</code>, <code>absent</code>, etc.  This is how examples in module documentation
+are typically presented.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_python_guidelines">3.4.7. Python Guidelines</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Review Ansible guidelines for
+<a href="https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_best_practices.html">modules</a>
+and <a href="https://docs.ansible.com/ansible/latest/dev_guide/index.html">development</a>.</p>
+</li>
+<li>
+<p>Use <a href="https://pep8.org/">PEP8</a>.</p>
+</li>
+<li>
+<p>File headers and functions should have comments for their intent.</p>
+</li>
+</ul>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_ansible_best_practices">3.4.8. Ansible Best Practices</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Ansible variables use lazy evaluation. <a href="https://github.com/ansible/ansible/issues/10374">more_info</a></p>
+</li>
+<li>
+<p>All tags should be namespaced/prefixed with the role name.</p>
+</li>
+<li>
+<p>Use preferably the command module instead of the shell module. Even better, use a dedicated module, if it
+exists. If not, see the <a href="#check-mode-and-idempotency-issues">section</a> about idempotency and check mode and
+make sure that you support them properly (your task will likely need options such as <code>changed_when:</code>
+and maybe <code>check_mode:</code> ). Anytime <code>command</code> or <code>shell</code> modules are used, a comment in the code with
+justification would help with future maintenance.</p>
+</li>
+<li>
+<p>Beware of bare variables (expressions consisting of just one variable reference without any
+operator) in <code>when</code>, their behavior is unexpected
+<a href="https://github.com/ansible/ansible/issues/39414">more_info</a>.</p>
+</li>
+<li>
+<p>Do not use <code>meta: end_play</code>. It aborts the whole play instead of a given host (with multiple
+hosts in the inventory) <a href="https://github.com/ansible/ansible/issues/27973">more_info</a> - We may
+consider using <code>meta: end_host</code> but this was recently introduced in Ansible 2.8
+<a href="https://github.com/ansible/ansible/pull/47194">more_info</a></p>
+</li>
+<li>
+<p>If reasonable, task names can be made dynamic by using variables (wrapped in Jinja2 templates), this helps
+with reading the logs. On the other hand, don&#8217;t do this for play names, variables don&#8217;t get expanded
+properly there.</p>
+</li>
+<li>
+<p>Do not override role defaults or vars or input parameters using <code>set_fact</code>. Use a different
+name instead. (Rationale: a fact set using <code>set_fact</code> can not be unset and it will override
+the role default or role variable in all subsequent invocations of the role in the same
+playbook. A fact has a different priority than other variables and not the highest, so in
+some cases overriding a given parameter will not work because the parameter has a higher priority)
+<a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable">more_info</a></p>
+</li>
+<li>
+<p>Use the smallest scope for variables. Facts are global for playbook run, so it is preferable
+to use other types of variables. Therefore limit (preferably avoid) the use of <code>set_fact</code>.
+Role variables are exposed to the whole play when the role is applied using <code>roles:</code> or
+<code>import_role:</code>. A more restricted scope such as task or block variables is preferred.</p>
+</li>
+<li>
+<p>Beware of <code>ignore_errors: yes</code>! Especially in tests. If you set on a block, it will ignore
+all the asserts in the block ultimately making them pointless. A comment in the code with
+justification is required to use this statement.</p>
+</li>
+<li>
+<p>Do not use the <code>eq</code> (introduced in Jinja 2.10) or <code>equalto</code> (introduced in Jinja 2.8) Jinja
+Operators - or any other post-2.7 Jinja2 features. (RHEL 7 has Jinja 2.7.2)</p>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/linux-system-roles/storage/pull/26" class="bare">https://github.com/linux-system-roles/storage/pull/26</a></p>
+</li>
+<li>
+<p><a href="https://github.com/linux-system-roles/storage/issues/49" class="bare">https://github.com/linux-system-roles/storage/issues/49</a></p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>All tasks should be idempotent, with notable and rare exceptions such as the
+<a href="https://github.com/AGP-roles/ansible_collection_system/tree/master/roles/reboot">AGP reboot role</a>.</p>
+</li>
+<li>
+<p>Avoid the use of <code>when: foo_result is changed</code> whenever possible. Use
+handlers, and, if necessary, handler
+chains to achieve this same result. Exceptions are permitted but they should be avoided when possible</p>
+</li>
+<li>
+<p>Use the various include/import statements in Ansible when doing so can lead to simplified code and a
+reduction of repetition. This is the closest that Ansible comes to callable sub-routines, so use judgment
+about callable routines to know when to similarly include a sub playbook. Some examples of good times
+to do so are</p>
+<div class="ulist">
+<ul>
+<li>
+<p>When a set of multiple commands share a single <code>when</code> conditional</p>
+</li>
+<li>
+<p>When a set of multiple commands are being looped together over a list of items</p>
+</li>
+<li>
+<p>When a single large role is doing many complicated tasks and cannot easily be broken into multiple roles,
+but the process proceeds in multiple related stages</p>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p>Avoid calling the <code>package</code> module iteratively with the <code>{{ item }}</code> argument, as this is impressively
+more slow than calling it with the line <code>name: "{{ foo_packages }}"</code>.  The same can go for many other
+modules that can be given an entire list of items all at once.</p>
+</li>
+<li>
+<p>Use meta modules when possible. Instead of using the <code>upstart</code> and <code>systemd</code> modules, use the <code>service</code>
+module when at all possible. Similarly for package management, use <code>package</code> instead of <code>yum</code> or <code>dnf</code> or
+similar. This will allow our playbooks to run on the widest selection of operating systems possible without
+having to modify any more tasks than is necessary.</p>
+</li>
+<li>
+<p>Avoid the use of <code>lineinfile</code> wherever that might be feasible.  Slight miscalculations in how it is used can
+lead to a loss of idempotence.  Modifying config files with it can cause the Ansible code to become arcane
+and difficult to read, especially for someone not familiar with the file in question.  Try editing files
+directly using other built-in modules (e.g. <code>ini_file</code>, <code>blockinfile</code>, <code>xml</code>), or reading and parsing. If
+you are modifying more than a tiny number of lines or in a manner more than trivially complex, try
+leveraging the <code>template</code> module, instead. This will allow the entire structure of the file to be seen by
+later users and maintainers. The use of <code>lineinfile</code> should include a comment with justification.</p>
+</li>
+<li>
+<p>Limit use of the <code>copy</code> module to copying remote files and to uploading binary blobs. For all other file
+pushes, use the <code>template</code> module. Even if there is nothing in the file that is being templated at the
+current moment, having the file handled by the <code>template</code> module now makes adding that functionality much
+simpler than if the file is initially handled by the <code>copy</code> and then needs to be moved before it can be
+edited.</p>
+</li>
+<li>
+<p>When using the <code>template</code> module, refrain from appending <code>.j2</code> to the file name. This alters the syntax
+highlighting in most editors and will obscure the benefits of highlighting for the particular file type or
+filename. Anything under the <code>templates</code> directory of a role is assumed to be treated as a Jinja 2 template,
+so adding the <code>.j2</code> extension is redundant information that is not helpful.</p>
+</li>
+<li>
+<p>Keep filenames and templates as close to the name on the destination system as possible. This will help with
+both editor highlighting as well as identifying source and destination versions of the file at a glance.
+Avoid duplicating the remote full path in the role directory, however, as that creates unnecessary depth in
+the file tree for the role. Grouping sets of similar files into a subdirectory of <code>templates</code> is allowable,
+but avoid unnecessary depth to the hierarchy.</p>
+</li>
+<li>
+<p>Use <code>{{ role_path }}/subdir/</code> as the filename prefix when including files if
+the name has a variable in it.  The problem is that your role may be
+included by another role, and if you specify a relative path, the file could
+be found in the including role.  For example, if you have something like
+<code>include_vars: "{{ ansible_facts['distribution'] }}.yml"</code> and you do not provide
+every possible <code>vars/{{ ansible_facts['distribution'] }}.yml</code> in your role,
+Ansible will look in the including role for this file.  Instead, to ensure
+that only your role will be referenced, use <code>include_vars: "{{
+role_path}}/vars/{{ ansible_facts['distribution'] }}.yml"</code>. Same with other file
+based includes such as <code>include_tasks</code>.
+See <a href="https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html#the-ansible-search-path">Ansible Search Path</a>
+for more information.</p>
+</li>
+</ul>
+</div>
+<div class="sect4">
+<h5 id="_vars_vs_defaults">3.4.8.1. Vars vs Defaults</h5>
+<div class="ulist">
+<ul>
+<li>
+<p>Avoid embedding large lists or "magic values" directly into the playbook. Such static lists should be
+placed into the <code>vars/main.yml</code> file and named appropriately</p>
+</li>
+<li>
+<p>Every argument accepted from outside of the role should be given a default value in <code>defaults/main.yml</code>.
+This allows a single place for users to look to see what inputs are expected. Document these variables
+in the role&#8217;s README.md file copiously</p>
+</li>
+<li>
+<p>Use the <code>defaults/main.yml</code> file in order to avoid use of the default Jinja2 filter within a playbook.
+Using the default filter is fine for optional keys on a dictionary, but the variable itself should be
+defined in <code>defaults/main.yml</code> so that it can have documentation written about it there and so that all
+arguments can easily be located and identified.</p>
+</li>
+<li>
+<p>Avoid giving default values in <code>vars/main.yml</code> as such values are very high in the precedence order and
+are difficult for users and consumers of a role to override.</p>
+</li>
+<li>
+<p>As an example, if a role requires a large number of packages to install, but could also accept a list of
+additional packages, then the required packages should be placed in <code>vars/main.yml</code> with a name such as
+<code>foo_packages</code>, and the extra packages should be passed in a variable named <code>foo_extra_packages</code>,
+which should default to an empty array in <code>defaults/main.yml</code> and be documented as such.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_documentation_conventions">3.4.9. Documentation conventions</h4>
+<div class="ulist">
+<ul>
+<li>
+<p>Use fully qualified role names in examples, like: <code>linux-system-roles.$ROLENAME</code> (with
+the Galaxy prefix).</p>
+</li>
+<li>
+<p>Use RFC <a href="https://tools.ietf.org/html/rfc5737">5737</a>,
+<a href="https://tools.ietf.org/html/rfc7042#section-2.1.1">7042</a> and
+<a href="https://tools.ietf.org/html/rfc3849">3849</a> addresses in examples.</p>
+</li>
+<li>
+<p>Modules should have complete metadata, documentation, example and return blocks as
+described in the
+<a href="https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html">Ansible docs</a>.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_references">3.5. References</h3>
+<div class="paragraph">
+<p>Links that contain additional standardization information that provide context,
+inspiration or contrast to the standards described above.</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><a href="https://github.com/debops/debops/blob/v0.7.2/docs/debops-policy/code-standards-policy.rst" class="bare">https://github.com/debops/debops/blob/v0.7.2/docs/debops-policy/code-standards-policy.rst</a>). For
+inspiration, as the DebOps project has some specific guidance that we do not necessarily
+want to follow.</p>
+</li>
+<li>
+<p><a href="https://docs.adfinis-sygroup.ch/public/ansible-guide/overview.html" class="bare">https://docs.adfinis-sygroup.ch/public/ansible-guide/overview.html</a></p>
+</li>
+<li>
+<p><a href="https://docs.openstack.org/openstack-ansible/latest/contributor/code-rules.html" class="bare">https://docs.openstack.org/openstack-ansible/latest/contributor/code-rules.html</a></p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_collections_good_practices">4. Collections good practices</h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Work in Progress&#8230;&#8203;
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_playbooks_good_practices">5. Playbooks good practices</h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Work in Progress&#8230;&#8203;
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_inventories_good_practices_for_ansible">6. Inventories Good Practices for Ansible</h2>
+<div class="sectionbody">
+<details>
+<summary class="title"><span class="big"><strong>Identify your Single Source(s) of Truth and use it/them in your inventory</strong></span></summary>
+<div class="content">
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Explanations</dt>
+<dd>
+<p>A Single Source of Truth (SSOT) is the place where the "ultimate" truth about a certain data is generated, stored and maintained.
+There can be more than one SSOT, each for a different piece of information, but they shouldn&#8217;t overlap and even less conflict.
+As you create your inventory, you identify these SSOTs and combine them into one inventory using dynamic inventory sources (we&#8217;ll see how later on).
+Only the aspects which are not already provided by other sources are kept statically in your inventory.
+Doing this, your inventory becomes another source of truth, but only for the data it holds statically, because there is no other place to keep it.</p>
+</dd>
+<dt class="hdlist1">Rationale</dt>
+<dd>
+<p>You limit your effort to maintain your inventory to its absolute minimum and you avoid generating potentially conflicting information with the rest of your IT.</p>
+</dd>
+<dt class="hdlist1">Examples</dt>
+<dd>
+<p>You can typically identify three kinds of candidates as SSOTs:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>technical ones, where your managed devices live anyway, like a cloud or virtual manager (OpenStack, RHV, Public Cloud API, &#8230;&#8203;) or management systems (Satellite, monitoring systems, &#8230;&#8203;). Those sources provide you with technical information like IP addresses, OS type, etc.</p>
+</li>
+<li>
+<p>managed ones, like a Configuration Management Database (CMDB), where your IT anyway manages a lot of information of use in an inventory. A CMDB provides you with more organizational information, like owner or location, but also with "to-be" technical information.</p>
+</li>
+<li>
+<p>the inventory itself, only for the data which doesn&#8217;t exist anywhere else.</p>
+<div class="paragraph">
+<p>Ansible provides a lot of <a href="https://docs.ansible.com/ansible/latest/plugins/inventory.html">inventory plugins</a> to pull data from those sources and they can be combined into one big inventory.
+This gives you a complete model of the environment to be automated, with limited effort to maintain it, and no confusion about where to modify it to get the result you need.</p>
+</div>
+</li>
+</ul>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+</details>
+<details>
+<summary class="title"><span class="big"><strong>Differentiate clearly between "As-Is" and "To-Be" information</strong></span></summary>
+<div class="content">
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Explanations</dt>
+<dd>
+<p>As you combine multiple sources, some will represent:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>discovered information grabbed from the existing environment, this is the "As-Is" information.</p>
+</li>
+<li>
+<p>managed information entered in a tool, expressing the state to be reached, hence the "To-Be" information.</p>
+<div class="paragraph">
+<p>In general, the focus of an inventory is on the managed information because it represents the desired state you want to reach with your automation. This said, some discovered information is required for the automation to work.</p>
+</div>
+</li>
+</ul>
+</div>
+</dd>
+<dt class="hdlist1">Rationale</dt>
+<dd>
+<p>Mixing up these two kind of information can lead to your automation taking the wrong course of action by thinking that the current situation is aligned with the desired state.
+That can make your automation go awry and your automation engineers confused.
+There is a reason why Ansible makes the difference between "facts" (As-Is) and "variables" (To-Be), and so should you.
+In the end, automation is making sure that the As-Is situation complies to the To-Be description.</p>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+many CMDBs have failed because they don&#8217;t respect this principle.
+This and the lack of automation leads to a mix of unmaintained As-Is and To-Be information with no clear guideline on how to keep them up-to-date, and no real motivation to do so.
+</td>
+</tr>
+</table>
+</div>
+</dd>
+<dt class="hdlist1">Examples</dt>
+<dd>
+<p>The technical tools typically contain a lot of discovered information, like an IP address or the RAM size of a VM.
+In a typical cloud environment, the IP address isn&#8217;t part of the desired state, it is assigned on the fly by the cloud management layer, so you can only get it dynamically from the cloud API and you won&#8217;t manage it.
+In a more traditional environment nevertheless, the IP address will be static, managed more or less manually, so it will become part of your desired state.
+In this case, you shouldn&#8217;t use the discovered information or you might not realize that there is a discrepancy betweeen As-Is and To-Be.</p>
+<div class="paragraph">
+<p>The RAM size of a VM will be always present in two flavours, e.g. As-Is coming from the technical source and To-Be coming from the CMDB, or your static inventory, and you shouldn&#8217;t confuse them.
+By lack of doing so, your automation might not correct the size of the VM where it should have aligned the As-Is with the To-Be.</p>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+</details>
+<details>
+<summary class="title"><span class="big"><strong>Define your inventory as structured directory instead of single file</strong></span></summary>
+<div class="content">
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Explanations</dt>
+<dd>
+<p>Everybody has started with a single file inventory in ini-format (the courageous ones among us in YAML format), combining list of hosts, groups and variables.
+An inventory can nevertheless be also a directory containing:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>list(s) of hosts</p>
+</li>
+<li>
+<p>list(s) of groups, with sub-groups and hosts belonging to those groups</p>
+</li>
+<li>
+<p>dynamic inventory plug-ins configuration files</p>
+</li>
+<li>
+<p>dynamic inventory scripts (deprecated but still simple to use)</p>
+</li>
+<li>
+<p>structured <code>host_vars</code> directories</p>
+</li>
+<li>
+<p>structured <code>group_vars</code> directories</p>
+<div class="paragraph">
+<p>The recommendation is to start with such a structure and extend it step by step.</p>
+</div>
+</li>
+</ul>
+</div>
+</dd>
+<dt class="hdlist1">Rationale</dt>
+<dd>
+<p>It is the only way to combine simply multiple sources into one inventory, without the trouble to call ansible with multiple <code>-i {inventory_file}</code> parameters, and keep the door open for extending it with dynamic elements.</p>
+<div class="paragraph">
+<p>It is also simpler to maintain in a Git repository with multiple maintainers as the chance to get a conflict is reduced because the information is spread among multiple files.
+You can drop roles' <code>defaults/main.yml</code> file into the structure and adapt it to your needs very quickly.</p>
+</div>
+<div class="paragraph">
+<p>And finally it gives you a better overview of what is in your inventory without having to dig deeply into it, because already the structure (as revealed with <code>tree</code> or <code>find</code>) gives you a first idea of where to search what. This makes on-boarding of new maintainers a lot easier.</p>
+</div>
+</dd>
+<dt class="hdlist1">Examples</dt>
+<dd>
+<p>The following is a complete inventory as described before.
+You don&#8217;t absolutely need to start at this level of complexity, but the experience shows that once you get used to it, it is actually a lot easier to understand and maintain than a single file.</p>
+<div class="listingblock">
+<div class="title">Listing 1. Tree of a structured inventory directory</div>
+<div class="content">
+<pre>inventory_example/  <i class="conum" data-value="1"></i><b>(1)</b>
+├── dynamic_inventory_plugin.yml  <i class="conum" data-value="2"></i><b>(2)</b>
+├── dynamic_inventory_script.py  <i class="conum" data-value="3"></i><b>(3)</b>
+├── groups_and_hosts  <i class="conum" data-value="4"></i><b>(4)</b>
+├── group_vars/  <i class="conum" data-value="5"></i><b>(5)</b>
+│   ├── alephs/
+│   │   └── capital_letter.yml
+│   ├── all/
+│   │   └── ansible.yml
+│   ├── alphas/
+│   │   ├── capital_letter.yml
+│   │   └── small_caps_letter.yml
+│   ├── betas/
+│   │   └── capital_letter.yml
+│   ├── greek_letters/
+│   │   └── small_caps_letter.yml
+│   └── hebrew_letters/
+│       └── small_caps_letter.yml
+└── host_vars/  <i class="conum" data-value="6"></i><b>(6)</b>
+    ├── host1.example.com/
+    │   └── ansible.yml
+    ├── host2.example.com/
+    │   └── ansible.yml
+    └── host3.example.com/
+        ├── ansible.yml
+        └── capital_letter.yml</pre>
+</div>
+</div>
+<div class="colist arabic">
+<table>
+<tr>
+<td><i class="conum" data-value="1"></i><b>1</b></td>
+<td>this is your inventory directory</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="2"></i><b>2</b></td>
+<td>a configuration file for a dynamic inventory plug-in</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="3"></i><b>3</b></td>
+<td>a dynamic inventory script, old style and deprecated but still used (and supported)</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="4"></i><b>4</b></td>
+<td>a file containing a static list of hosts and groups, the name isn&#8217;t important (often called <code>hosts</code> but some might confuse it with <code>/etc/hosts</code> and it also contains groups).
+See below for an example.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="5"></i><b>5</b></td>
+<td>the <code>group_vars</code> directory to define group variables.
+Notice how each group is represented by a directory of its name containing one or more variable files.</td>
+</tr>
+<tr>
+<td><i class="conum" data-value="6"></i><b>6</b></td>
+<td>the <code>host_vars</code> directory to define host variables.
+Notice how each host is represented by a directory of its name containing one or more variable files.</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>The groups and hosts file could look as follows, important is to not put any variable definition in this file.</p>
+</div>
+<div class="listingblock">
+<div class="title">Listing 2. Content of the <code>groups_and_hosts</code> file</div>
+<div class="content">
+<pre class="rouge highlight"><code data-lang="ini"><span class="nn">[all]</span>
+<span class="err">host1.example.com</span>
+<span class="err">host2.example.com</span>
+<span class="err">host3.example.com</span>
+
+<span class="nn">[alphas]</span>
+<span class="err">host1.example.com</span>
+
+<span class="nn">[betas]</span>
+<span class="err">host2.example.com</span>
+
+<span class="nn">[greek_letters:children]</span>
+<span class="err">alphas</span>
+<span class="err">betas</span>
+
+<span class="nn">[alephs]</span>
+<span class="err">host3.example.com</span>
+
+<span class="nn">[hebrew_letters:children]</span>
+<span class="err">alephs</span></code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Listing the hosts under <code>[all]</code> isn&#8217;t really required but makes sure that no host is forgotten, should it not belong to any other group.
+The ini-format isn&#8217;t either an obligation but it seems easier to read than YAML, as long as no variable is involved, and makes it easier to maintain in an automated manner using <code>lineinfile</code> (without needing to care for the indentation).</p>
+</div>
+<div class="paragraph">
+<p>Regarding the group and host variables, the name of the variable files is actually irrelevant, you can verify it by calling <code>ansible-inventory -i inventory_example --list</code>:
+you will see nowhere the name <code>capital_letter</code> or <code>small_caps_letter</code> (you might see <code>ansible</code> though, but for other reasons&#8230;&#8203;).
+We nevertheless follow the convention to name our variable files after the role they are steering (so we assume the roles <code>capital_letter</code> and <code>small_caps_letter</code>).
+If correctly written, the <code>defaults/main.yml</code> file from those roles can be simply "dropped" into our inventory structure and adapted accordingly to our needs.
+We reserve the name <code>ansible.yml</code> for the Ansible related variables (user, connection, become, etc).</p>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-tip" title="Tip"></i>
+</td>
+<td class="content">
+you can even create a sub-directory in a host&#8217;s or group&#8217;s variable directory and put <em>there</em> the variable files.
+This is useful if you have many variables related to the same topic you want to group together but maintain in separate files.
+For example Satellite requires many variables to be fully configured, so you can have a structure as follows (again, the name of the sub-directory <code>satellite</code> and of the files doesn&#8217;t matter):
+</td>
+</tr>
+</table>
+</div>
+<div class="listingblock">
+<div class="title">Listing 3. Example of a complex tree of variables with sub-directory</div>
+<div class="content">
+<pre>inventory_satellite/
+├── groups_and_hosts
+└── host_vars/
+    └── sat6.example.com/
+        ├── ansible.yml
+        └── satellite/
+            ├── content_views.yml
+            ├── hostgroups.yml
+            └── locations.yml</pre>
+</div>
+</div>
+</dd>
+</dl>
+</div>
+</div>
+</details>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_plugins_good_practices">7. Plugins good practices</h2>
+<div class="sectionbody">
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+Work in Progress&#8230;&#8203;
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-04-18 07:04:23 +0200
+</div>
+</div>
+<style>
+pre.rouge table td { padding: 5px; }
+pre.rouge table pre { margin: 0; }
+pre.rouge .cm {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .cp {
+  color: #999999;
+  font-weight: bold;
+}
+pre.rouge .c1 {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+pre.rouge .c, pre.rouge .ch, pre.rouge .cd, pre.rouge .cpf {
+  color: #999988;
+  font-style: italic;
+}
+pre.rouge .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+pre.rouge .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+pre.rouge .ge {
+  color: #000000;
+  font-style: italic;
+}
+pre.rouge .gr {
+  color: #aa0000;
+}
+pre.rouge .gh {
+  color: #999999;
+}
+pre.rouge .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+pre.rouge .go {
+  color: #888888;
+}
+pre.rouge .gp {
+  color: #555555;
+}
+pre.rouge .gs {
+  font-weight: bold;
+}
+pre.rouge .gu {
+  color: #aaaaaa;
+}
+pre.rouge .gt {
+  color: #aa0000;
+}
+pre.rouge .kc {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kd {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kn {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kp {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kr {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kt {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .k, pre.rouge .kv {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .mf {
+  color: #009999;
+}
+pre.rouge .mh {
+  color: #009999;
+}
+pre.rouge .il {
+  color: #009999;
+}
+pre.rouge .mi {
+  color: #009999;
+}
+pre.rouge .mo {
+  color: #009999;
+}
+pre.rouge .m, pre.rouge .mb, pre.rouge .mx {
+  color: #009999;
+}
+pre.rouge .sa {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .sb {
+  color: #d14;
+}
+pre.rouge .sc {
+  color: #d14;
+}
+pre.rouge .sd {
+  color: #d14;
+}
+pre.rouge .s2 {
+  color: #d14;
+}
+pre.rouge .se {
+  color: #d14;
+}
+pre.rouge .sh {
+  color: #d14;
+}
+pre.rouge .si {
+  color: #d14;
+}
+pre.rouge .sx {
+  color: #d14;
+}
+pre.rouge .sr {
+  color: #009926;
+}
+pre.rouge .s1 {
+  color: #d14;
+}
+pre.rouge .ss {
+  color: #990073;
+}
+pre.rouge .s, pre.rouge .dl {
+  color: #d14;
+}
+pre.rouge .na {
+  color: #008080;
+}
+pre.rouge .bp {
+  color: #999999;
+}
+pre.rouge .nb {
+  color: #0086B3;
+}
+pre.rouge .nc {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .no {
+  color: #008080;
+}
+pre.rouge .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+pre.rouge .ni {
+  color: #800080;
+}
+pre.rouge .ne {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nf, pre.rouge .fm {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nl {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nn {
+  color: #555555;
+}
+pre.rouge .nt {
+  color: #000080;
+}
+pre.rouge .vc {
+  color: #008080;
+}
+pre.rouge .vg {
+  color: #008080;
+}
+pre.rouge .vi {
+  color: #008080;
+}
+pre.rouge .nv, pre.rouge .vm {
+  color: #008080;
+}
+pre.rouge .ow {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .o {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .w {
+  color: #bbbbbb;
+}
+pre.rouge {
+  background-color: #f8f8f8;
+}
+</style>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -444,7 +444,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_introduction">1. Introduction</a></li>
-<li><a href="#_automation_structures">2. Automation structures</a></li>
+<li><a href="#_automation_structures">2. Automation structures</a>
+<ul class="sectlevel2">
+<li><a href="#_define_which_structure_to_use_for_which_purpose">2.1. Define which structure to use for which purpose</a></li>
+</ul>
+</li>
 <li><a href="#_roles_good_practices_for_ansible">3. Roles Good Practices for Ansible</a>
 <ul class="sectlevel2">
 <li><a href="#_background">3.1. Background</a></li>
@@ -483,7 +487,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_collections_good_practices">4. Collections good practices</a></li>
 <li><a href="#_playbooks_good_practices">5. Playbooks good practices</a></li>
-<li><a href="#_inventories_good_practices_for_ansible">6. Inventories Good Practices for Ansible</a></li>
+<li><a href="#_inventories_good_practices_for_ansible">6. Inventories Good Practices for Ansible</a>
+<ul class="sectlevel2">
+<li><a href="#_identify_your_single_sources_of_truth_and_use_itthem_in_your_inventory">6.1. Identify your Single Source(s) of Truth and use it/them in your inventory</a></li>
+<li><a href="#_differentiate_clearly_between_as_is_and_to_be_information">6.2. Differentiate clearly between "As-Is" and "To-Be" information</a></li>
+<li><a href="#_define_your_inventory_as_structured_directory_instead_of_single_file">6.3. Define your inventory as structured directory instead of single file</a></li>
+</ul>
+</li>
 <li><a href="#_plugins_good_practices">7. Plugins good practices</a></li>
 </ul>
 </div>
@@ -554,8 +564,10 @@ It also has great educational value for understanding how things actually work (
 <p>Before we start to describe roles, playbooks, etc, we need to decide which one we use for what.
 This section is meant for topics which span across multiple structures and don&#8217;t fit nicely within one.</p>
 </div>
+<div class="sect2">
+<h3 id="_define_which_structure_to_use_for_which_purpose">2.1. Define which structure to use for which purpose</h3>
 <details>
-<summary class="title"><span class="big"><strong>Define which structure to use for which purpose</strong></span></summary>
+<summary class="title">Details</summary>
 <div class="content">
 <div class="dlist">
 <dl>
@@ -656,6 +668,7 @@ As long as exceptions are discussed openly in the team, they won&#8217;t hurt.</
 </div>
 </div>
 </details>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1494,8 +1507,10 @@ Work in Progress&#8230;&#8203;
 <div class="sect1">
 <h2 id="_inventories_good_practices_for_ansible">6. Inventories Good Practices for Ansible</h2>
 <div class="sectionbody">
+<div class="sect2">
+<h3 id="_identify_your_single_sources_of_truth_and_use_itthem_in_your_inventory">6.1. Identify your Single Source(s) of Truth and use it/them in your inventory</h3>
 <details>
-<summary class="title"><span class="big"><strong>Identify your Single Source(s) of Truth and use it/them in your inventory</strong></span></summary>
+<summary class="title">Details</summary>
 <div class="content">
 <div class="dlist">
 <dl>
@@ -1536,8 +1551,11 @@ This gives you a complete model of the environment to be automated, with limited
 </div>
 </div>
 </details>
+</div>
+<div class="sect2">
+<h3 id="_differentiate_clearly_between_as_is_and_to_be_information">6.2. Differentiate clearly between "As-Is" and "To-Be" information</h3>
 <details>
-<summary class="title"><span class="big"><strong>Differentiate clearly between "As-Is" and "To-Be" information</strong></span></summary>
+<summary class="title">Details</summary>
 <div class="content">
 <div class="dlist">
 <dl>
@@ -1593,8 +1611,11 @@ By lack of doing so, your automation might not correct the size of the VM where 
 </div>
 </div>
 </details>
+</div>
+<div class="sect2">
+<h3 id="_define_your_inventory_as_structured_directory_instead_of_single_file">6.3. Define your inventory as structured directory instead of single file</h3>
 <details>
-<summary class="title"><span class="big"><strong>Define your inventory as structured directory instead of single file</strong></span></summary>
+<summary class="title">Details</summary>
 <div class="content">
 <div class="dlist">
 <dl>
@@ -1777,6 +1798,7 @@ For example Satellite requires many variables to be fully configured, so you can
 </div>
 </div>
 </details>
+</div>
 </div>
 </div>
 <div class="sect1">

--- a/inventories/README.adoc
+++ b/inventories/README.adoc
@@ -1,6 +1,6 @@
 = Inventories Good Practices for Ansible
 
-.[big]#**Identify your Single Source(s) of Truth and use it/them in your inventory**#
+== Identify your Single Source(s) of Truth and use it/them in your inventory
 [%collapsible]
 ====
 Explanations::
@@ -25,7 +25,7 @@ This gives you a complete model of the environment to be automated, with limited
 ====
 
 
-.[big]#**Differentiate clearly between "As-Is" and "To-Be" information**#
+== Differentiate clearly between "As-Is" and "To-Be" information
 [%collapsible]
 ====
 Explanations::
@@ -56,7 +56,7 @@ By lack of doing so, your automation might not correct the size of the VM where 
 ====
 
 
-.[big]#**Define your inventory as structured directory instead of single file**#
+== Define your inventory as structured directory instead of single file
 [%collapsible]
 ====
 Explanations::

--- a/playbooks/README.adoc
+++ b/playbooks/README.adoc
@@ -1,1 +1,3 @@
 = Playbooks good practices
+
+NOTE: Work in Progress...

--- a/plugins/README.adoc
+++ b/plugins/README.adoc
@@ -1,1 +1,3 @@
 = Plugins good practices
+
+NOTE: Work in Progress...

--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -1,5 +1,7 @@
 = Roles Good Practices for Ansible
 
+NOTE: this section has been imported "as-is" from the https://github.com/oasis-roles/meta_standards[OASIS metastandards repository] and still requires re-formatting to fit the overall structure.
+
 == Background
 
 The goal of the Ansible Metateam project (specifically, the https://github.com/linux-system-roles[Linux System Roles

--- a/structures/README.adoc
+++ b/structures/README.adoc
@@ -3,7 +3,7 @@
 Before we start to describe roles, playbooks, etc, we need to decide which one we use for what.
 This section is meant for topics which span across multiple structures and don't fit nicely within one.
 
-.[big]#**Define which structure to use for which purpose**#
+== Define which structure to use for which purpose
 [%collapsible]
 ====
 Explanations::

--- a/structures/README.adoc
+++ b/structures/README.adoc
@@ -1,5 +1,4 @@
 = Automation structures
-include::../_style/render.adoc[]
 
 Before we start to describe roles, playbooks, etc, we need to decide which one we use for what.
 This section is meant for topics which span across multiple structures and don't fit nicely within one.


### PR DESCRIPTION
There are two commits in this PR:

The first one adds a `docs/index.html` file.

The idea would be to generate `docs/index.html` (and CONTRIBUTE.html) later on automatically through a pipeline. The same pipeline could create also the PDF

For now manual creation will do, so that https://redhat-cop.github.io/automation-good-practices/ offers a rendered version of the good practices.

The 2nd commit changes the recommendations' title into sections. This makes the table of content much more meaningful and renders also better in PDF:
![image](https://user-images.githubusercontent.com/3105685/115135531-71466f00-a019-11eb-8d7a-9ef60b8e276d.png)
Compared to the previous rendering:
![image](https://user-images.githubusercontent.com/3105685/115135549-9fc44a00-a019-11eb-8244-d990f19e33ee.png)

I kept two separate commits so that you can compare the outputs of the HTML.
