### PR TITLE
introduce PDF generating and Makefile

### DIFF
--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -98,7 +98,7 @@ Examples:: These are examples
 Even more examples...
 ====
 
-== Publishing
+== Publishing as HTML
 
 Use for now the following manual command:
 
@@ -111,3 +111,29 @@ cp _images/*.svg docs/_images
 ----
 
 NOTE: it doesn't seem that there is any much better way to keep links to images correct according to the https://docs.asciidoctor.org/asciidoctor/latest/html-backend/manage-images/[HTML generation / managed images] chapter.
+
+== Creating a PDF
+
+If you run (a current) Fedora Linux,
+then you can use the `Makefile`.
+
+* `make view` generates both PDF files and displays the GPA guide
+* `make print` prints to your default printer
+* `make spell` runs hunspell for spellchecking
+* …
+
+Alternatively, use the following manual commands to generate the 2 PDFs:
+
+[source,bash]
+----
+asciidoctor-pdf \
+  --attribute=gitdate=$(git log -1 --date=short --pretty=format:%cd) \
+  --attribute=githash=$(git rev-parse --verify HEAD) \
+  --out-file Good_Practices_for_Ansible.pdf \
+  README.adoc
+asciidoctor-pdf \
+  --attribute=gitdate=$(git log -1 --date=short --pretty=format:%cd) \
+  --attribute=githash=$(git rev-parse --verify HEAD) \
+  --out-file Contributing-to-GPA.pdf \
+  CONTRIBUTE.adoc
+----

--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -98,7 +98,7 @@ Examples:: These are examples
 Even more examples...
 ====
 
-== Publishing as HTML
+== Publish for the website
 
 Use for now the following manual command:
 

--- a/CONTRIBUTE.adoc
+++ b/CONTRIBUTE.adoc
@@ -100,7 +100,8 @@ Even more examples...
 
 == Publish for the website
 
-Use for now the following manual command:
+Use for now the following manual command to publish to
+link:++https://redhat-cop.github.io/automation-good-practices/++[the website]:
 
 [source,bash]
 ----

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# be sure to have the following RPMs installed on Fedora Linux
+#
+# okular
+# asciidoctor-pdf
+# rubygem-rugged
+# hunspell
+# hunspell-en-GB
+# rubygem-ffi ?
+# rubygem-json ?
+
+ADOCPDF = asciidoctor-pdf --attribute=gitdate=$(shell git log -1 --date=short --pretty=format:%cd) --attribute=githash=$(shell git rev-parse --verify HEAD)
+ACROREAD = okular
+VCS = git
+INFILE = README.adoc
+INFILE2 = CONTRIBUTE.adoc
+OUTFILE = Good_Practices_for_Ansible.pdf
+OUTFILE2 = Contributing-to-GPA.pdf
+PRINT = lpr
+SPELL = hunspell
+SPELLOPTS = -d en_GB
+
+
+all: $(OUTFILE)
+
+$(OUTFILE): $(INFILE) *.adoc */*.adoc _images/* Makefile
+	$(ADOCPDF) --out-file $(OUTFILE) $(INFILE)
+	$(ADOCPDF) --out-file $(OUTFILE2) $(INFILE2)
+
+view: viewpdf
+
+print: $(OUTFILE)
+	$(PRINT) $(OUTFILE)
+
+viewpdf: $(OUTFILE)
+	$(ACROREAD) $(OUTFILE)
+
+clean:
+	rm -f $(OUTFILE)
+	rm -rf .AppleDouble
+
+spell:
+	$(SPELL) $(SPELLOPTS) *.adoc */*.adoc
+
+commit: clean
+	$(VCS) commit .
+
+push: clean
+	$(VCS) push
+
+pull:
+	$(VCS) pull

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ SPELLOPTS = -d en_GB
 
 all: $(OUTFILE)
 
-$(OUTFILE): $(INFILE) *.adoc */*.adoc _images/* Makefile
+$(OUTFILE): $(INFILE) *.adoc */*.adoc _images/* Makefile .git/index
 	$(ADOCPDF) --out-file $(OUTFILE) $(INFILE)
 	$(ADOCPDF) --out-file $(OUTFILE2) $(INFILE2)
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ viewpdf: $(OUTFILE)
 
 clean:
 	rm -f $(OUTFILE)
+	rm -f $(OUTFILE2)
 	rm -rf .AppleDouble
 
 spell:


### PR DESCRIPTION
addresses redhat-cop/automation-good-practices#21

This MR was created after thinking _oh, I'd like a PDF and I have a Makefile I regularly use anyway_.
Do tell if you would like creation of the HTML tree  added to the `Makefile` and your preferred target name if any.

`{gitdate}` and `{githash}` can be used in the AsciiDoc source