### PR TITLE
Fix ansible_managed guideline to use comment filter

### DIFF
--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -346,8 +346,7 @@ exists for each provider supported, or use an explicit, absolute path using
 === Generating files from templates
 [%collapsible]
 ====
-* Comment with ``{{ ansible_managed }}``at the top of the file.
-https://docs.ansible.com/ansible/latest/modules/template_module.html#template-module[more_info]
+* Add ``{{ ansible_managed | comment }}`` at the top of the template file file to indicate that the file is managed by Ansible roles. For more information, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#id38[Adding comments to files].
 * When commenting, don't include anything like "Last modified: {{ date }}". This would change the file at
 every application of the role, even if it doesn't need to be changed for other reasons, and thus break
 proper change reporting.

--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -346,7 +346,8 @@ exists for each provider supported, or use an explicit, absolute path using
 === Generating files from templates
 [%collapsible]
 ====
-* Add ``{{ ansible_managed | comment }}`` at the top of the template file file to indicate that the file is managed by Ansible roles. For more information, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#id38[Adding comments to files].
+* Add ``{{ ansible_managed | comment }}`` at the top of the template file file to indicate that the file is managed by Ansible roles, while making sure that multi-line values are properly commented.
+For more information, see https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#adding-comments-to-files[Adding comments to files].
 * When commenting, don't include anything like "Last modified: {{ date }}". This would change the file at
 every application of the role, even if it doesn't need to be changed for other reasons, and thus break
 proper change reporting.


### PR DESCRIPTION
The issue is that when a user has the `ansible_managed` variable set to a multi-line entry, `# {{ ansible_managed }}` in templates expands to the ansible_managed variable with only the first line commented out.
Ansible guidelines suggest replacing `# {{ ansible_managed }}` with `{{ ansible_managed | comment }}` so that all lines are commented out.
For more info, see e.g. https://bugzilla.redhat.com/show_bug.cgi?id=2006230