### PR TITLE
Update role guidance to capture dashes in role names causing issues with collections

### DIFF
--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -98,6 +98,7 @@ https://github.com/geerlingguy/ansible-role-apache/blob/f2b91ac84001db3fd4b43306
 includes variables set by set_fact and register, because they persist in the namespace after the
 role has finished!
 * Prefix all tags within a role with the role name or, alternatively, a "unique enough" but descriptive prefix.
+* Do not use dashes in role names. This will cause issues with collections.
 ====
 
 === Providers


### PR DESCRIPTION
Capturing the issue with dashes in role names being a problem in collections (See https://chat.google.com/room/AAAAarh_G-k/4cgukM5sPqw )