### PR TITLE
Ensure that the website is regen everytime with the correct footer

### DIFF
--- a/.github/workflows/make_docs.yml
+++ b/.github/workflows/make_docs.yml
@@ -2,8 +2,8 @@ name: publish document
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - main
 
 jobs:
   build:

--- a/_style/render.adoc
+++ b/_style/render.adoc
@@ -11,6 +11,9 @@
 :listing-caption: Listing
 :imagesdir: images/
 
+:revnumber: {gitdate} (commit: {githash})
+:!last-update-label:
+
 // The following lines could become relevant in the future
 
 ////


### PR DESCRIPTION
The footer will be generated based on the latest GIT commit. An example could be (for the previous git commit):

    Version 2022-11-30 (commit: b88dd1d0689dea9e7742df3913ca2b5dba63bd1f)

Fixes #81 