### PR TITLE
Fix: minor spelling errors

### DIFF
--- a/inventories/README.adoc
+++ b/inventories/README.adoc
@@ -50,7 +50,7 @@ Examples::
 The technical tools typically contain a lot of discovered information, like an IP address or the RAM size of a VM.
 In a typical cloud environment, the IP address isn't part of the desired state, it is assigned on the fly by the cloud management layer, so you can only get it dynamically from the cloud API and you won't manage it.
 In a more traditional environment nevertheless, the IP address will be static, managed more or less manually, so it will become part of your desired state.
-In this case, you shouldn't use the discovered information or you might not realize that there is a discrepancy betweeen As-Is and To-Be.
+In this case, you shouldn't use the discovered information or you might not realize that there is a discrepancy between As-Is and To-Be.
 +
 The RAM size of a VM will be always present in two flavours, e.g. As-Is coming from the technical source and To-Be coming from the CMDB, or your static inventory, and you shouldn't confuse them.
 By lack of doing so, your automation might not correct the size of the VM where it should have aligned the As-Is with the To-Be.
@@ -268,7 +268,7 @@ Explanations::
 
 Rationale::
 There are https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#understanding-variable-precedence[22 levels of variable precedence].
-This is almost impossible to keep in mind for a "normal" human and can lead to all kind of weird behaviours if not under control.
+This is almost impossible to keep in mind for a "normal" human and can lead to all kind of weird behaviors if not under control.
 In addition, the use of play(book) variables is not recommended as it blurs the separation between code and data.
 The same applies to all constructs including specific variable files as part of the play (i.e. `include_vars`).
 By reducing the number of variable types, you end up with a more simple and overseeable list of variables.

--- a/plugins/README.adoc
+++ b/plugins/README.adoc
@@ -15,7 +15,7 @@ NOTE: Work in Progress...
 Explanations::
 All plugins, regardless of type, need documentation that describes the input parameters, outputs, and practical examples of how to use it.
 
-Examples:: See the Ansible Developer Guide sections on https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#plugin-configuration-documentation-standards[Plugin Configuration and Documentation Standards] and https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#module-documenting[Module Documentating] for more details.
+Examples:: See the Ansible Developer Guide sections on https://docs.ansible.com/ansible/latest/dev_guide/developing_plugins.html#plugin-configuration-documentation-standards[Plugin Configuration and Documentation Standards] and https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#module-documenting[Module Documenting] for more details.
 ====
 
 == Use sphinx (reST) formatted docstrings in Python code
@@ -104,7 +104,7 @@ def test_split_pre_existing_dir_one_level_exists(directory, expected, mocker):
 [%collapsible]
 ====
 Explanations::
-Ensure a consistent approach to the way commplex argument_specs are formatted within a collection.
+Ensure a consistent approach to the way complex argument_specs are formatted within a collection.
 
 Rationale::
 When hand-writing a complex argspec, the author may choose to build up to data structure from multiple dictionaries or vars.

--- a/structures/README.adoc
+++ b/structures/README.adoc
@@ -10,10 +10,10 @@ Explanations::
 define for which use case to use roles, playbooks, potentially workflows (in Ansible Controller/Tower/AWX), and how to split the code you write.
 
 Rationale::
-especially when writing automation in a team, it is important to have a certain level of consistence and make sure everybody has the same understanding.
+especially when writing automation in a team, it is important to have a certain level of consistency and make sure everybody has the same understanding.
 By lack of doing so, your automation becomes unreadable and difficult to grasp for new members or even for existing members.
 +
-This structure will also help you to have a consistent level of modelization so that re-usability becomes easier.
+This structure will also help you to have a consistent level of modularization so that re-usability becomes easier.
 If one team member uses roles where another one uses playbooks, they will both struggle to reuse the code of each other.
 Metaphorically speaking, only if stones have been cut at roughly the same size, can they be properly used to build a house.
 

--- a/structures/README.adoc
+++ b/structures/README.adoc
@@ -13,7 +13,7 @@ Rationale::
 especially when writing automation in a team, it is important to have a certain level of consistency and make sure everybody has the same understanding.
 By lack of doing so, your automation becomes unreadable and difficult to grasp for new members or even for existing members.
 +
-This structure will also help you to have a consistent level of modularization so that re-usability becomes easier.
+Following a consistent structure will increase re-usability.
 If one team member uses roles where another one uses playbooks, they will both struggle to reuse the code of each other.
 Metaphorically speaking, only if stones have been cut at roughly the same size, can they be properly used to build a house.
 


### PR DESCRIPTION
Minor spelling errors, normalized on "American English" in accordance with [Ansible documentation style guide](https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html#id3)