### PR TITLE
Add html link checker schedule

### DIFF
--- a/.github/workflows/issue_template_broken_link.md
+++ b/.github/workflows/issue_template_broken_link.md
@@ -1,0 +1,13 @@
+---
+title: Website Contains Broken Links
+labels: 'bug'
+assignees: ''
+---
+
+## Broken Links Detected
+
+Broken Link Checker found broken links on https://redhat-cop.github.io/automation-good-practices/
+
+[View Results](https://github.com/redhat-cop/automation-good-practices/actions/workflows/test_html_links.yml)
+
+_Use search filter `─BROKEN─` to highlight failures_

--- a/.github/workflows/issue_template_broken_link.md
+++ b/.github/workflows/issue_template_broken_link.md
@@ -1,7 +1,6 @@
 ---
 title: Website Contains Broken Links
-labels: 'bug'
-assignees: ''
+labels: Bug
 ---
 
 ## Broken Links Detected

--- a/.github/workflows/test_html_links.yml
+++ b/.github/workflows/test_html_links.yml
@@ -1,0 +1,27 @@
+#Check the rendered page for dead links
+name: Broken Links Checker
+on:
+  schedule:
+    - cron:  '12 1 * * 5'
+  workflow_dispatch:
+env:
+  WEBSITE_URL: "https://redhat-cop.github.io/automation-good-practices/"
+  ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Run Broken Links Checker
+      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0"
+
+    - uses: actions/checkout@v3
+      if: failure()
+
+    - uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        filename: ".github/workflows/check-broken-links.md"
+      if: failure()

--- a/.github/workflows/test_html_links.yml
+++ b/.github/workflows/test_html_links.yml
@@ -1,20 +1,23 @@
 #Check the rendered page for dead links
 name: Broken Links Checker
+permissions:
+  contents: read
+  issues: write
 on:
   schedule:
-    - cron:  '12 1 * * 5'
+    - cron:  '0 16 * * *'
   workflow_dispatch:
 env:
   WEBSITE_URL: "https://redhat-cop.github.io/automation-good-practices/"
-  ISSUE_TEMPLATE: ".github/workflows/check-broken-links.md"
+  ISSUE_TEMPLATE: ".github/workflows/issue_template_broken_link.md"
 
 jobs:
-  check:
+  check_links:
     runs-on: ubuntu-latest
 
     steps:
     - name: Run Broken Links Checker
-      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0"
+      run: npx broken-link-checker $WEBSITE_URL --ordered --recursive --user-agent "Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0" --exclude "https://opensource.org/licenses/BSD-2-Clause"
 
     - uses: actions/checkout@v3
       if: failure()
@@ -23,5 +26,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        filename: ".github/workflows/check-broken-links.md"
+        filename: ${{ env.ISSUE_TEMPLATE }}
       if: failure()


### PR DESCRIPTION
closes #99

Together with the markdown link check we now can be sure we don't have broken links in the code nor in the published page. The new action runs on a schedule so that we get notified even if we don't make any changes.

To see it in action have a look at https://github.com/mophahr/test_link_checker