### PR TITLE
Update fact check to use sorted comparison

### DIFF
--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -235,7 +235,7 @@ Examples::
   setup:
     gather_subset: min
   when: not ansible_facts.keys() | list |
-    intersect(__rolename_required_facts) == __rolename_required_facts
+    intersect(__rolename_required_facts) | sort == __rolename_required_facts | sort
 
 - name: Set platform/version specific variables
   include_vars: "{{ __rolename_vars_file }}"

--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -234,8 +234,7 @@ Examples::
 - name: Ensure ansible_facts used by role
   setup:
     gather_subset: min
-  when: not ansible_facts.keys() | list |
-    intersect(__rolename_required_facts) | sort == __rolename_required_facts | sort
+  when: __rolename_required_facts | difference(ansible_facts.keys() | list) | length > 0
 
 - name: Set platform/version specific variables
   include_vars: "{{ __rolename_vars_file }}"


### PR DESCRIPTION
Ensure required facts are checked in a sorted manner.
When comparing them unsorted they do not match like below
```
- debug:
    msg: "{{ ansible_facts.keys() | list | intersect(__sudo_required_facts) }}"
- debug:
    msg: "{{ __sudo_required_facts }}"
```
```
TASK [sudo : debug] ***************************************************************************************************************************************************************************
ok: [cloud01] => {
    "msg": [
        "distribution_major_version",
        "system",
        "distribution",
        "distribution_version",
        "os_family"
    ]
}

TASK [sudo : debug] ***************************************************************************************************************************************************************************
ok: [cloud01] => {
    "msg": [
        "system",
        "os_family",
        "distribution",
        "distribution_major_version",
        "distribution_version"
    ]
}
```