### PR TITLE
docs(roles): require loop_control.loop_var with __ prefix

### DIFF
--- a/coding_style/README.adoc
+++ b/coding_style/README.adoc
@@ -194,7 +194,7 @@ Task files that are very or and/or contain highly nested blocks are difficult to
 Breaking a large or complex task file into multiple discrete files makes it easier to read and understand what is being done in each part.
 ====
 
-* Use bracket notation instead of dot notation for value retrieval (e.g. `item['key']` vs. `item.key`)
+* Use bracket notation instead of dot notation for value retrieval (e.g. `__rolename_entry['key']` vs. `__rolename_entry.key`)
 +
 [%collapsible]
 ====
@@ -247,7 +247,7 @@ tasks:
 ====
 
 * Do not use variables (wrapped in Jinja2 templates) for play names; variables don't get expanded properly there.
-  The same applies to loop variables (by default `item`) in task names within a loop.
+  The same applies to loop variables (do not use bare `item`; use `loop_control.loop_var` with a `__` prefixed name) in task names within a loop.
   They, too, don't get properly expanded and hence are not to be used there.
 * Do not override role defaults or vars or input parameters using `set_fact`.
   Use a different name instead.
@@ -316,7 +316,7 @@ Some examples of good times to do so are
 * When a single large role is doing many complicated tasks and cannot easily be broken into multiple roles, but the process proceeds in multiple related stages
 ====
 
-* Avoid calling the `package` module iteratively with the `{{ item }}` argument, as this is impressively more slow than calling it with the line `name: "{{ foo_packages }}"`.
+* Avoid calling the `package` module iteratively in a loop (with the `{{ item }}` argument), as this is impressively more slow than calling it with the line `name: "{{ foo_packages }}"`.
 The same can go for many other modules that can be given an entire list of items all at once.
 * Use meta modules when possible.
 +

--- a/inventories/README.adoc
+++ b/inventories/README.adoc
@@ -254,7 +254,7 @@ Saturday 23 October 2021  13:11:56 +0200 (0:00:00.569)       0:00:00.610 ******
 create some file to simulate an API call to provision a host ------------ 0.57s
 ----
 +
-TIP: if for some reason, you can't follow the recommendation, you can at least avoid duplicating too much information by indirectly referencing the hosts' variables as in `"{{ hostvars[item.name]['provision_value'] }}"`. Not so bad...
+TIP: if for some reason, you can't follow the recommendation, you can at least avoid duplicating too much information by indirectly referencing the hosts' variables as in `"{{ hostvars[__provision_host.name]['provision_value'] }}"` (with `loop_control.loop_var: __provision_host`). Not so bad...
 ====
 
 == Restrict your usage of variable types

--- a/inventories/inventory_loop_hosts/playbook_bad.yml
+++ b/inventories/inventory_loop_hosts/playbook_bad.yml
@@ -5,10 +5,12 @@
   tasks:
     - name: Create some file to simulate an API call to provision a host
       ansible.builtin.copy:
-        content: "{{ item.provision_value }}\n"
-        dest: "/tmp/bad_{{ inventory_hostname }}_{{ item.name }}.txt"
+        content: "{{ __provision_host.provision_value }}\n"
+        dest: "/tmp/bad_{{ inventory_hostname }}_{{ __provision_host.name }}.txt"
         force: true
         owner: root
         group: root
         mode: "0644"
       loop: "{{ provision_list_of_hosts }}"
+      loop_control:
+        loop_var: __provision_host

--- a/inventories/inventory_loop_hosts/playbook_not_so_bad.yml
+++ b/inventories/inventory_loop_hosts/playbook_not_so_bad.yml
@@ -5,10 +5,12 @@
   tasks:
     - name: Create some file to simulate an API call to provision a host
       ansible.builtin.copy:
-        content: "{{ hostvars[item.name]['provision_value'] }}\n"
-        dest: "/tmp/not_so_bad_{{ inventory_hostname }}_{{ item.name }}.txt"
+        content: "{{ hostvars[__provision_host.name]['provision_value'] }}\n"
+        dest: "/tmp/not_so_bad_{{ inventory_hostname }}_{{ __provision_host.name }}.txt"
         force: true
         owner: root
         group: root
         mode: "0644"
       loop: "{{ provision_list_of_hosts }}"
+      loop_control:
+        loop_var: __provision_host

--- a/roles/README.adoc
+++ b/roles/README.adoc
@@ -124,6 +124,25 @@ Using the name of the role reduces the potential for name conflicts and using th
 The two underscores convention has prior art in some popular roles like
 https://github.com/geerlingguy/ansible-role-apache/blob/f2b91ac84001db3fd4b43306a8f73f1a54f96f7d/vars/Debian.yml#L8[geerlingguy.ansible-role-apache]).
 This includes variables set by set_fact and register, because they persist in the namespace after the role has finished!
+* In roles, do not use the default Ansible loop variable `item`. Set `loop_control.loop_var` to an internal name prefixed with `__` (and ideally the role name), then reference that name in the task `vars:` block and in `when:` conditions.
++
+Rationale:: `item` is generic and leaks into the play namespace; it is easy to clash with another loop or with a host variable. A dedicated `__rolename_*` loop variable makes intent obvious and matches the internal-variable convention.
++
+Example::
++
+[source,yaml]
+----
+- name: Set platform/version specific variables
+  ansible.builtin.include_vars: "{{ __rolename_vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+  loop_control:
+    loop_var: __rolename_vars_candidate
+  vars:
+    __rolename_vars_file: "{{ role_path }}/vars/{{ __rolename_vars_candidate }}"
+  when: __rolename_vars_file is file
+----
 * Prefix all tags within a role with the role name or, alternatively, a "unique enough" but descriptive prefix.
 * Do not use dashes in role names. This will cause issues with collections.
 ====
@@ -244,8 +263,10 @@ Examples::
     - "{{ ansible_facts['distribution'] }}.yml"
     - "{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"
     - "{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
+  loop_control:
+    loop_var: __rolename_vars_candidate
   vars:
-    __rolename_vars_file: "{{ role_path }}/vars/{{ item }}"
+    __rolename_vars_file: "{{ role_path }}/vars/{{ __rolename_vars_candidate }}"
   when: __rolename_vars_file is file
 ----
 
@@ -269,7 +290,7 @@ The files in the `loop` are in order from least specific to most specific:
 See https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#ansible-facts-distribution[Commonly Used Facts] for an explanation of the facts and their common values.
 
 Each file in the `loop` list will allow you to add or override variables to specialize the values for platform and/or version.
-Using the `when: item is file` test means that you do not have to provide all of the `vars/` files, only the ones you need.
+Using the `when: __rolename_vars_file is file` test means that you do not have to provide all of the `vars/` files, only the ones you need.
 For example, if every platform except Fedora uses `srv_name` for the service name, you can define `myrole_service: srv_name` in `vars/main.yml` then define `myrole_service: srv2_name` in `vars/Fedora.yml`.
 In cases where this would lead to duplicate vars files for similar distributions (e.g. CentOS 7 and RHEL 7), use symlinks to avoid the duplication.
 
@@ -292,8 +313,10 @@ If this is a problem, construct the file list as a list variable, and filter the
 - name: Set platform/version specific variables
   include_vars: "{{ __rolename_vars_file }}"
   loop: "{{ __rolename_vars_file_list | unique | list }}"
+  loop_control:
+    loop_var: __rolename_vars_candidate
   vars:
-    __rolename_vars_file: "{{ role_path }}/vars/{{ item }}"
+    __rolename_vars_file: "{{ role_path }}/vars/{{ __rolename_vars_candidate }}"
   when: __rolename_vars_file is file
 ----
 

--- a/roles/dont_use_groups/playbook.yml
+++ b/roles/dont_use_groups/playbook.yml
@@ -6,13 +6,17 @@
   tasks:
     - name: The loop happens for each host, might be too much
       ansible.builtin.debug:
-        msg: do something with {{ item }}
+        msg: do something with {{ __cluster_member }}
       loop: "{{ groups[cluster_group_name] }}"
+      loop_control:
+        loop_var: __cluster_member
 
     - name: The loop happens only for the first host in each group
       ansible.builtin.debug:
-        msg: do something with {{ item }}
+        msg: do something with {{ __cluster_member }}
       loop: "{{ groups[cluster_group_name] }}"
+      loop_control:
+        loop_var: __cluster_member
       when: inventory_hostname == groups[cluster_group_name][0]
 
     - name: Make the first host of each group fail to simulate non-availability
@@ -21,8 +25,10 @@
 
     - name: The loop happens only for the first _available_ host in each group
       ansible.builtin.debug:
-        msg: do something with {{ item }}
+        msg: do something with {{ __cluster_member }}
       loop: "{{ groups[cluster_group_name] }}"
+      loop_control:
+        loop_var: __cluster_member
       when: >-
         inventory_hostname == (groups[cluster_group_name]
         | intersect(ansible_play_hosts))[0]

--- a/roles/dont_use_groups/playbook2.yml
+++ b/roles/dont_use_groups/playbook2.yml
@@ -7,9 +7,11 @@
   tasks:
     - name: Add last host to execution group (why not the last one?)
       ansible.builtin.add_host:
-        name: "{{ groups[item][-1] }}"
+        name: "{{ groups[__cluster_group][-1] }}"
         groups: cluster_execution_group
       loop: "{{ groups | select('match', '^cluster_group_.$') | list }}"
+      loop_control:
+        loop_var: __cluster_group
 
 - name: Now execute something on each first host of each cluster
   hosts: cluster_execution_group
@@ -19,5 +21,7 @@
   tasks:
     - name: The loop happens for each execution host
       ansible.builtin.debug:
-        msg: do something with {{ item }}
+        msg: do something with {{ __cluster_member }}
       loop: "{{ groups[cluster_group_name] }}"
+      loop_control:
+        loop_var: __cluster_member


### PR DESCRIPTION
Document that role loops must not use bare item; use internal __rolename_* loop variables. Update platform vars examples.