### PR TITLE
Updating README to reflect current naming conventions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ If they are new to Ansible, the https://docs.ansible.com/ansible/latest/user_gui
 the https://docs.ansible.com/[official Ansible documentation] is a better place to start.
 
 This document is split in six main sections.
-Each section covers a different aspect of automation using Ansible (and in a broader term the whole https://www.redhat.com/en/technologies/management/ansible[Red Hat Ansible Automation Platform], including Ansible Controller):
+Each section covers a different aspect of automation using Ansible and in a broader term the whole https://www.redhat.com/en/technologies/management/ansible[Red Hat Ansible Automation Platform]:
 
 . structures: we need to know what to use for which purpose before we can delve into the details, this section explains this.
 . roles: as we recommend to use roles to host the most actual Ansible code, this is also where we'll cover the more low level aspects of code (tasks, variables, etc...).

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ If they are new to Ansible, the https://docs.ansible.com/ansible/latest/user_gui
 the https://docs.ansible.com/[official Ansible documentation] is a better place to start.
 
 This document is split in six main sections.
-Each section covers a different aspect of automation using Ansible (and in a broader term the whole https://www.redhat.com/en/technologies/management/ansible[Red Hat Ansible Automation Platform], including Ansible Tower):
+Each section covers a different aspect of automation using Ansible (and in a broader term the whole https://www.redhat.com/en/technologies/management/ansible[Red Hat Ansible Automation Platform], including Ansible Controller):
 
 . structures: we need to know what to use for which purpose before we can delve into the details, this section explains this.
 . roles: as we recommend to use roles to host the most actual Ansible code, this is also where we'll cover the more low level aspects of code (tasks, variables, etc...).

--- a/structures/README.adoc
+++ b/structures/README.adoc
@@ -40,7 +40,7 @@ Automation is a continuous journey that never ends.
 [%collapsible]
 ====
 Explanations::
-define for which use case to use roles, playbooks, potentially workflows (in Ansible Controller/Tower/AWX), and how to split the code you write.
+define for which use case to use roles, playbooks, potentially workflows (in Ansible Controller/AWX), and how to split the code you write.
 
 Rationale::
 especially when writing automation in a team, it is important to have a certain level of consistency and make sure everybody has the same understanding.
@@ -57,7 +57,7 @@ The following is only one example of how to structure your content but has prove
 image::ansible_structures.svg[a hierarchy of landscape type function and component]
 +
 * a _landscape_ is anything you want to deploy at once, the underlay of your cloud, a three tiers application, a complete application cluster...
-  This level is represented at best by a Controller/Tower/AWX workflow, potentially by a "playbook of playbooks", i.e. a playbook made of imported _type_ playbooks, as introduced next.
+  This level is represented at best by a Controller/AWX workflow, potentially by a "playbook of playbooks", i.e. a playbook made of imported _type_ playbooks, as introduced next.
 * a _type_ must be defined such that each managed host has one and only one type, applicable using a unique playbook.
 * each type is then made of multiple _functions_, represented by roles, so that the same function used by the same _type_ can be re-used, written only once.
 * and finally _components_ are used to split a _function_ in maintainable bits. By default a component is a task file within the _function_-role, if the role becomes too big, there is a case for splitting the _function_ role into multiple _component_ roles.


### PR DESCRIPTION
Replace outdated 'Ansible Tower'/'Tower' references with 'Ansible Controller' to reflect current AAP naming.